### PR TITLE
change: cast everything else to string

### DIFF
--- a/lib/csv/encoder.ex
+++ b/lib/csv/encoder.ex
@@ -54,6 +54,10 @@ defmodule CSV.Encoder do
 
   defp encode_cell(cell, separator, delimiter) do
     cond do
+      !is_bitstring(cell) and !is_list(cell) ->
+        @double_quote <>
+        to_string(cell) <>
+        @double_quote
       String.contains?(cell, [separator, delimiter, @carriage_return, @newline]) ->
         @double_quote <>
         (cell |> escape |> String.replace(@double_quote, @double_quote <> @double_quote)) <>


### PR DESCRIPTION
It raise an exception when i try to encode a list of number and atom.


So, i simply use `to_string` macro to cast everything else, should modify
later to use a filter to cast certain basic types, and at last use protocol
allowing user extend `CSV.Encoder` behaviour.