### PR TITLE
clarify dependency inclusion instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,17 @@ Now.
 ## How do I get it?
 Add
 ```elixir
-[{:csv, "~> 1.1.0"}]
+{:csv, "~> 1.1.0"}
 ```
-to your deps in `mix.exs`
+to your deps in `mix.exs` like so:
 
+```elixir
+defp deps do
+  [
+    {:csv, "~> 1.1.0"}
+  ]
+end
+```
 ## Great! How do I use it right now?
 
 Do this to decode:


### PR DESCRIPTION
This is a super small change, but I think it makes it clearer for folks who may be new to Elixir.

In the README on line 19 it says to add

`[{:csv, "~> 1.1.0"}]`

to your `mix.exs` deps, but this makes it seem as if you should put a list with a single tuple inside the list the `deps` function contains. So, I just clarified it a little bit and think it might help someone out if they are working quickly and just skim the README for a quick experiment.

Thanks for the great work!