### PR TITLE
Fix encoding of cells containing double quotes

### DIFF
--- a/lib/csv/encode.ex
+++ b/lib/csv/encode.ex
@@ -38,7 +38,8 @@ defimpl CSV.Encode, for: BitString do
         << separator :: utf8 >>,
         delimiter,
         << @carriage_return :: utf8 >>,
-        << @newline :: utf8 >>
+        << @newline :: utf8 >>,
+        << @double_quote :: utf8 >>
       ]) ->
         << @double_quote :: utf8 >> <>
       (data |> escape |> String.replace(

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -5,6 +5,10 @@ defmodule EncodeTest do
     assert CSV.Encode.encode(",this") == "\",this\""
   end
 
+  test "it correctly escapes double quotes" do
+    assert CSV.Encode.encode("a\"b") == "\"a\"\"b\""
+  end
+
   test "it falls back to to_string for integers" do
     assert CSV.Encode.encode(1) == "1"
   end


### PR DESCRIPTION
Fixed encoding of cells containing double quote characters. Previously, cells containing a double quote were not escaped.

For example, previously

> [["a", "Sub 4\" Paving", "b"]]

was encoded as

> a,Sub 4" Paving,b

which is not correct. This change fixes it so that it is encoded as:

> a,"Sub 4"" Paving",b