### PR TITLE
if multiple options are specified, then strip_cells is ignored

### DIFF
--- a/lib/csv/parser.ex
+++ b/lib/csv/parser.ex
@@ -71,10 +71,11 @@ defmodule CSV.Parser do
     { :ok, row ++ [field |> strip(options)] }
   end
 
-  defp strip(field, [ strip_cells: true ]) do
-    field |> String.strip
-  end
-  defp strip(field, _) do
-    field
+  defp strip(field, options \\ []) do
+    strip_cells = options |> Keyword.get(:strip_cells, false)
+    case strip_cells do
+      true -> field |> String.strip
+      _ -> field
+    end
   end
 end

--- a/test/decoder_test.exs
+++ b/test/decoder_test.exs
@@ -60,6 +60,16 @@ defmodule DecoderTest do
     ]
   end
 
+  test "parses strings and strips cells when headers are given and strip_cells is true" do
+    stream = Stream.map(["h1,h2", "a, be", "c,d"], &(&1))
+    result = Decoder.decode(stream, headers: true, strip_cells: true) |> Enum.into([])
+
+    assert result == [
+      %{"h1" => "a", "h2" => "be"},
+      %{"h1" => "c", "h2" => "d"}
+    ]
+  end
+
   test "parses strings into maps when headers are given as a list" do
     stream = Stream.map(["a,be", "c,d"], &(&1))
     result = Decoder.decode(stream, headers: [:a, :b]) |> Enum.into([])

--- a/test/decoder_test.exs
+++ b/test/decoder_test.exs
@@ -61,11 +61,11 @@ defmodule DecoderTest do
   end
 
   test "parses strings and strips cells when headers are given and strip_cells is true" do
-    stream = Stream.map(["h1,h2", "a, be", "c,d"], &(&1))
+    stream = Stream.map(["h1,h2", "a, be free ", "c,d"], &(&1))
     result = Decoder.decode(stream, headers: true, strip_cells: true) |> Enum.into([])
 
     assert result == [
-      %{"h1" => "a", "h2" => "be"},
+      %{"h1" => "a", "h2" => "be free"},
       %{"h1" => "c", "h2" => "d"}
     ]
   end


### PR DESCRIPTION
Test case. When specifying headers and strip_cells, then strip_cells was ignored. I changed it to be consistent with the way Lex works, etc., by checking if the option is set.

```File.stream!("data/user_1/data.csv") |> CSV.decode(strip_cells: true, headers: true) |> Enum.each(fn(row) -> IO.inspect(row) end)```

oh.. forgot to open an issue for this. 