### PR TITLE
add mode argument to File.open! in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ And you'll get a stream of lines ready to be written to an IO.
 So, this is writing to a file:
 
 ````elixir
-file = File.open!("test.csv")
+file = File.open!("test.csv", [:write])
 table_data |> CSV.encode |> Enum.each(&IO.write(file, &1))
 ````
 


### PR DESCRIPTION
This is a correction for the usage of `File.open!/2` in the encoding and writing to file example.