### PR TITLE
Make decode return errors in a tuple and decode! raise errors

### DIFF
--- a/lib/csv.ex
+++ b/lib/csv.ex
@@ -33,14 +33,14 @@ defmodule CSV do
   Convert a filestream into a stream of rows:
 
       iex> File.stream!(\"data.csv\") |>
-      iex> CSV.decode |>
+      iex> CSV.decode! |>
       iex> Enum.take(2)
       [[\"a\",\"b\",\"c\"], [\"d\",\"e\",\"f\"]]
 
   Convert a filestream into a stream of rows in order of the given stream:
 
       iex> File.stream!(\"data.csv\") |>
-      iex> CSV.decode(num_pipes: 1) |>
+      iex> CSV.decode!(num_pipes: 1) |>
       iex> Enum.take(2)
       [[\"a\",\"b\",\"c\"], [\"d\",\"e\",\"f\"]]
 
@@ -48,7 +48,7 @@ defmodule CSV do
 
       iex> [\"a;b\",\"c;d\", \"e;f\"] |>
       iex> Stream.map(&(&1)) |>
-      iex> CSV.decode(separator: ?;, headers: true) |>
+      iex> CSV.decode!(separator: ?;, headers: true) |>
       iex> Enum.take(2)
       [%{\"a\" => \"c\", \"b\" => \"d\"}, %{\"a\" => \"e\", \"b\" => \"f\"}]
 
@@ -56,7 +56,7 @@ defmodule CSV do
 
       iex> [\"a;b\",\"c;d\", \"e;f\"] |>
       iex> Stream.map(&(&1)) |>
-      iex> CSV.decode(separator: ?;, headers: [:x, :y]) |>
+      iex> CSV.decode!(separator: ?;, headers: [:x, :y]) |>
       iex> Enum.take(2)
       [%{:x => \"a\", :y => \"b\"}, %{:x => \"c\", :y => \"d\"}]
   """

--- a/lib/csv.ex
+++ b/lib/csv.ex
@@ -65,6 +65,9 @@ defmodule CSV do
     CSV.Decoder.decode(stream, options)
   end
 
+  def decode!(stream, options \\ []) do
+    CSV.Decoder.decode!(stream, options)
+  end
 
   @doc """
   Encode a table stream into a stream of RFC 4180 compliant CSV lines for writing to a file

--- a/lib/csv/decoder.ex
+++ b/lib/csv/decoder.ex
@@ -102,7 +102,7 @@ defmodule CSV.Decoder do
     { :ok, headers |> Enum.zip(data) |> Enum.into(%{}) }
   end
   defp build_row(data, _), do: { :ok, data }
-  
+
   defp options_with_defaults(options) do
     num_pipes = options |> Keyword.get(:num_pipes, Defaults.num_workers)
     options
@@ -121,7 +121,7 @@ defmodule CSV.Decoder do
   defp prepare_headers(job), do: job
 
   defp prepare_row_length({ stream, %{ headers: headers } = options}) do
-    { stream, %{ options | :headers => get_row_length(headers || stream, options) } }
+    { stream, %{ options | :row_length => get_row_length(headers || stream, options) } }
   end
 
   defp check_row_length(_, false), do: { :ok }

--- a/lib/csv/decoder.ex
+++ b/lib/csv/decoder.ex
@@ -63,7 +63,7 @@ defmodule CSV.Decoder do
 
   def decode!(stream, options \\ []) do
     decode(stream, options)
-    |> handle_errors!
+    |> raise_errors!
   end
 
   def decode(stream, options \\ []) do
@@ -151,7 +151,7 @@ defmodule CSV.Decoder do
     data
   end
 
-  defp handle_errors!(stream) do
+  defp raise_errors!(stream) do
     stream |> Stream.map(&monad_value!/1)
   end
   defp monad_value!({ :error, mod, message, index }) do

--- a/lib/csv/decoder.ex
+++ b/lib/csv/decoder.ex
@@ -154,8 +154,11 @@ defmodule CSV.Decoder do
     process_line({ { first_line, 0 }, false }, options)
   end
 
-  defp handle_errors!({ :error, error }) do
-    raise error
+  defp handle_errors!({ :error, mod, message }) do
+    monad_value!({ :error, mod, message, 0 })
+  end
+  defp handle_errors!({ :error, _, _, _ } = monad) do
+    monad_value!(monad)
   end
   defp handle_errors!({ :ok, stream }) do
     stream |> Stream.map(&monad_value!/1)

--- a/lib/csv/decoder.ex
+++ b/lib/csv/decoder.ex
@@ -67,54 +67,66 @@ defmodule CSV.Decoder do
   end
 
   def decode(stream, options \\ []) do
-    with options <- options_with_defaults(options),
-         { :ok, { headers, stream } } <-
-           get_headers(options |> Keyword.get(:headers), stream, options),
-         { :ok, row_length } <-
-           get_row_length(headers || stream, options),
-         do: { :ok,
-               process_stream({ stream, row_length }, options |> Keyword.merge(headers: headers))}
+    { stream, options |> options_with_defaults }
+    |> prepare_headers
+    |> prepare_row_length
+    |> decode_stream
   end
 
-  defp process_stream({ stream, row_length }, options) do
+  defp decode_stream({ stream, %{ multiline_escape: multiline_escape } = options }) do
     stream
-    |> aggregate(options |> Keyword.get(:multiline_escape))
+    |> aggregate(multiline_escape)
     |> Stream.with_index
-    |> ParallelStream.map(&(process_line({ &1, row_length }, options)),
-                          options)
+    |> ParallelStream.map(&(decode_row(&1, options)),
+                          options |> Enum.into([]))
   end
 
+  defp decode_row({ nil, 0 }, %{ row_length: false }), do: { :ok, [] }
+  defp decode_row({ line, index }, %{ headers: headers, row_length: row_length } = options) do
+    with { :ok, parsed, _ } <- parse_row({ line, index }, options |> Enum.into([])),
+         { :ok } <- check_row_length({ parsed, index }, row_length),
+         do: build_row(parsed, headers)
+  end
+
+  defp parse_row({ line, index}, options) do
+    with { :ok, lex, _ } <- Lexer.lex({ line, index }, options),
+    do: Parser.parse({ lex, index }, options)
+  end
+
+  defp aggregate(stream, true) do
+    stream |> LineAggregator.aggregate
+  end
+  defp aggregate(stream, false), do: stream
+
+  defp build_row(data, headers) when is_list(headers) do
+    { :ok, headers |> Enum.zip(data) |> Enum.into(%{}) }
+  end
+  defp build_row(data, _), do: { :ok, data }
+  
   defp options_with_defaults(options) do
     num_pipes = options |> Keyword.get(:num_pipes, Defaults.num_workers)
     options
     |> Keyword.merge(num_pipes: num_pipes,
                      num_workers: options |> Keyword.get(:num_workers, num_pipes),
                      multiline_escape: options |> Keyword.get(:multiline_escape, true),
-                     headers: options |> Keyword.get(:headers, false))
+                     headers: options |> Keyword.get(:headers, false),
+                     row_length: false)
+    |> Enum.into(%{})
   end
 
-  defp process_line({ { nil, _ }, _ }) do
-    []
+  defp prepare_headers({ stream, %{ headers: true } = options }) do
+    { stream |> Stream.drop(1),
+      %{ options | :headers => get_first_row(stream, options) } }
   end
-  defp process_line({ { line, index }, row_length }, options) do
-    with { :ok, lex, _ } <- Lexer.lex({ line, index }, options),
-         { :ok, parsed, _ } <- Parser.parse({ lex, index }, options),
-         { :ok } <- check_row_length({ parsed, index }, row_length),
-         do: build_row(parsed, options |> Keyword.get(:headers))
+  defp prepare_headers(job), do: job
+
+  defp prepare_row_length({ stream, %{ headers: headers } = options}) do
+    { stream, %{ options | :headers => get_row_length(headers || stream, options) } }
   end
 
-  defp aggregate(stream, true) do
-    stream |> LineAggregator.aggregate
-  end
-  defp aggregate(stream, false) do
-    stream
-  end
-
-  defp check_row_length(_, false) do
-    { :ok }
-  end
+  defp check_row_length(_, false), do: { :ok }
   defp check_row_length({ data, index }, row_length) do
-    actual_length = data |> Enum.count
+    actual_length = get_row_length(data)
 
     case actual_length do
       ^row_length -> { :ok }
@@ -122,55 +134,29 @@ defmodule CSV.Decoder do
     end
   end
 
-  defp build_row(data, headers) when is_list(headers) do
-    { :ok, headers |> Enum.zip(data) |> Enum.into(%{}) }
-  end
-  defp build_row(data, _) do
-    { :ok, data }
-  end
-
-  defp get_headers(headers, stream, _) when is_list(headers) do
-    { :ok, { headers, stream } }
-  end
-  defp get_headers(headers, stream, options) when headers do
-    with { :ok, headers} <- get_first_row(stream, options),
-    do: { :ok, { headers, stream |> Stream.drop(1) } }
-  end
-  defp get_headers(_, stream, _) do
-    { :ok, { false, stream } }
-  end
-
   defp get_row_length(%Stream{} = stream, options) do
-    with { :ok, row } <- get_first_row(stream, options),
-    do: get_row_length(row)
+    stream
+    |> get_first_row(options)
+    |> get_row_length
   end
-  defp get_row_length(row) do
-    { :ok, Enum.count(row) }
-  end
+  defp get_row_length(row, _), do: row |> get_row_length
+  defp get_row_length(row), do: Enum.count(row)
 
   defp get_first_row(stream, options) do
-    data = stream
-      |> LineAggregator.aggregate(options)
-      |> Enum.take(1)
-      |> List.first
-
-      process_line({ { data, 0 }, false }, options)
+    row = stream
+            |> LineAggregator.aggregate(options |> Enum.into([]))
+            |> Enum.take(1)
+            |> List.first
+    { :ok, data } = decode_row({ row, 0 }, options)
+    data
   end
 
-  defp handle_errors!({ :error, mod, message }) do
-    monad_value!({ :error, mod, message, 0 })
-  end
-  defp handle_errors!({ :error, _, _, _ } = monad) do
-    monad_value!(monad)
-  end
-  defp handle_errors!({ :ok, stream }) do
+  defp handle_errors!(stream) do
     stream |> Stream.map(&monad_value!/1)
   end
   defp monad_value!({ :error, mod, message, index }) do
     raise mod, message: message, line: index + 1
   end
-  defp monad_value!({ :ok, row }) do
-    row
-  end
+  defp monad_value!({ :ok, row }), do: row
 
 end

--- a/lib/csv/decoder.ex
+++ b/lib/csv/decoder.ex
@@ -67,7 +67,8 @@ defmodule CSV.Decoder do
   end
 
   def decode(stream, options \\ []) do
-    { stream, options |> options_with_defaults }
+    stream
+    |> with_default_options(options)
     |> prepare_headers
     |> prepare_row_length
     |> decode_stream
@@ -94,8 +95,6 @@ defmodule CSV.Decoder do
     do: build_row(parsed, headers)
   end
 
-  #defp decode_row({ nil, 0 }, %{ row_length: false }), do: { :ok, [] }
-
   defp parse_row({ line, index}, options) do
     with { :ok, lex, _ } <- Lexer.lex({ line, index }, options),
     do: Parser.parse({ lex, index }, options)
@@ -111,15 +110,17 @@ defmodule CSV.Decoder do
   end
   defp build_row(data, _), do: { :ok, data }
 
-  defp options_with_defaults(options) do
+  defp with_default_options(stream, options) do
     num_pipes = options |> Keyword.get(:num_pipes, Defaults.num_workers)
 
-    options
+    options = options
     |> Keyword.merge(num_pipes: num_pipes,
                      num_workers: options |> Keyword.get(:num_workers, num_pipes),
                      multiline_escape: options |> Keyword.get(:multiline_escape, true),
                      headers: options |> Keyword.get(:headers, false),
                      row_length: false)
+
+    { stream, options }
   end
 
   defp prepare_headers({ stream, options } = payload) do

--- a/lib/csv/decoder.ex
+++ b/lib/csv/decoder.ex
@@ -40,7 +40,7 @@ defmodule CSV.Decoder do
   Convert a filestream into a stream of rows:
 
       iex> File.stream!(\"data.csv\") |>
-      iex> CSV.Decoder.decode |>
+      iex> CSV.Decoder.decode! |>
       iex> Enum.take(2)
       [[\"a\",\"b\",\"c\"], [\"d\",\"e\",\"f\"]]
 
@@ -48,7 +48,7 @@ defmodule CSV.Decoder do
 
       iex> [\"a;b\",\"c;d\", \"e;f\"] |>
       iex> Stream.map(&(&1)) |>
-      iex> CSV.Decoder.decode(separator: ?;, headers: true) |>
+      iex> CSV.Decoder.decode!(separator: ?;, headers: true) |>
       iex> Enum.take(2)
       [%{\"a\" => \"c\", \"b\" => \"d\"}, %{\"a\" => \"e\", \"b\" => \"f\"}]
 
@@ -56,7 +56,7 @@ defmodule CSV.Decoder do
 
       iex> [\"a;b\",\"c;d\", \"e;f\"] |>
       iex> Stream.map(&(&1)) |>
-      iex> CSV.Decoder.decode(separator: ?;, headers: [:x, :y]) |>
+      iex> CSV.Decoder.decode!(separator: ?;, headers: [:x, :y]) |>
       iex> Enum.take(2)
       [%{:x => \"a\", :y => \"b\"}, %{:x => \"c\", :y => \"d\"}]
   """
@@ -73,7 +73,7 @@ defmodule CSV.Decoder do
     |> simplify_errors
   end
 
-  defp decode_stream(stream, options \\ []) do
+  defp decode_stream(stream, options) do
     stream
     |> with_default_options(options)
     |> prepare_headers
@@ -88,7 +88,7 @@ defmodule CSV.Decoder do
     |> ParallelStream.map(&(decode_row(&1, options)), options)
   end
 
-  defp decode_row({ nil, 0 }, options) do
+  defp decode_row({ nil, 0 }, _) do
     { :ok, [] }
   end
   defp decode_row({ line, index }, options) do

--- a/test/csv_test.exs
+++ b/test/csv_test.exs
@@ -8,9 +8,9 @@ defmodule CSVTest do
 
   test "decodes" do
     stream = Stream.map(["a,be", "c,d"], &(&1))
-    result = CSV.decode(stream) |> Enum.into([]) |> Enum.sort
 
-    assert result == [~w(a be), ~w(c d)]
+    assert (CSV.decode!(stream) |> Enum.into([]) |> Enum.sort) == [~w(a be), ~w(c d)]
+    assert (CSV.decode(stream) |> Enum.into([]) |> Enum.sort) == [ ok: ~w(a be), ok: ~w(c d) ]
   end
 
 end

--- a/test/csv_test.exs
+++ b/test/csv_test.exs
@@ -8,9 +8,11 @@ defmodule CSVTest do
 
   test "decodes" do
     stream = Stream.map(["a,be", "c,d"], &(&1))
-
     assert (CSV.decode!(stream) |> Enum.into([]) |> Enum.sort) == [~w(a be), ~w(c d)]
-    assert (CSV.decode(stream) |> Enum.into([]) |> Enum.sort) == [ ok: ~w(a be), ok: ~w(c d) ]
   end
 
+  test "decodes emitting a stram of monads" do
+    stream = Stream.map(["a,be", "c,d"], &(&1))
+    assert (CSV.decode(stream) |> Enum.into([]) |> Enum.sort) == [ ok: ~w(a be), ok: ~w(c d) ]
+  end
 end

--- a/test/decoder_test.exs
+++ b/test/decoder_test.exs
@@ -10,49 +10,49 @@ defmodule DecoderTest do
 
   test "parses strings into a list of token tuples and emits them" do
     stream = Stream.map(["a,be", "c,d"], &(&1))
-    result = Decoder.decode(stream) |> Enum.into([])
+    result = Decoder.decode!(stream) |> Enum.into([])
 
     assert result == [~w(a be), ~w(c d)]
   end
 
   test "parses empty lines into a list of token tuples" do
     stream = Stream.map([",", "c,d"], &(&1))
-    result = Decoder.decode(stream) |> Enum.into([])
+    result = Decoder.decode!(stream) |> Enum.into([])
 
     assert result == [["", ""], ~w(c d)]
   end
 
   test "parses partially populated lines into a list of token tuples" do
     stream = Stream.map([",ci,\"\"", ",c,d"], &(&1))
-    result = Decoder.decode(stream) |> Enum.into([])
+    result = Decoder.decode!(stream) |> Enum.into([])
 
     assert result == [["", "ci", ""], ["", "c", "d"]]
   end
 
   test "parses strings separated by custom separators into a list of token tuples and emits them" do
     stream = Stream.map(["a;be", "c;d"], &(&1))
-    result = Decoder.decode(stream, separator: ?;) |> Enum.into([])
+    result = Decoder.decode!(stream, separator: ?;) |> Enum.into([])
 
     assert result == [~w(a be), ~w(c d)]
   end
 
   test "parses strings separated by custom tab separators into a list of token tuples and emits them" do
     stream = Stream.map(["a\tbe", "c\td"], &(&1))
-    result = Decoder.decode(stream, separator: ?\t) |> Enum.into([])
+    result = Decoder.decode!(stream, separator: ?\t) |> Enum.into([])
 
     assert result == [~w(a be), ~w(c d)]
   end
 
   test "parses strings and strips cells when given the option" do
     stream = Stream.map(["  a , be", "c,    d\t"], &(&1))
-    result = Decoder.decode(stream, strip_cells: true) |> Enum.into([])
+    result = Decoder.decode!(stream, strip_cells: true) |> Enum.into([])
 
     assert result == [~w(a be), ~w(c d)]
   end
 
   test "parses strings into maps when headers are set to true" do
     stream = Stream.map(["a,be", "c,d", "e,f"], &(&1))
-    result = Decoder.decode(stream, headers: true) |> Enum.into([])
+    result = Decoder.decode!(stream, headers: true) |> Enum.into([])
 
     assert result |> Enum.sort == [
       %{"a" => "c", "be" => "d"},
@@ -62,7 +62,7 @@ defmodule DecoderTest do
 
   test "parses strings and strips cells when headers are given and strip_cells is true" do
     stream = Stream.map(["h1,h2", "a, be free ", "c,d"], &(&1))
-    result = Decoder.decode(stream, headers: true, strip_cells: true) |> Enum.into([])
+    result = Decoder.decode!(stream, headers: true, strip_cells: true) |> Enum.into([])
 
     assert result == [
       %{"h1" => "a", "h2" => "be free"},
@@ -72,7 +72,7 @@ defmodule DecoderTest do
 
   test "parses strings into maps when headers are given as a list" do
     stream = Stream.map(["a,be", "c,d"], &(&1))
-    result = Decoder.decode(stream, headers: [:a, :b]) |> Enum.into([])
+    result = Decoder.decode!(stream, headers: [:a, :b]) |> Enum.into([])
 
     assert result == [
       %{:a => "a", :b => "be"},
@@ -82,7 +82,7 @@ defmodule DecoderTest do
 
   test "parses strings that contain single double quotes" do
     stream = Stream.map(["a,be", "\"c\"\"\",d"], &(&1))
-    result = Decoder.decode(stream) |> Enum.into([])
+    result = Decoder.decode!(stream) |> Enum.into([])
 
     assert result == [["a", "be"], ["c\"", "d"]]
   end
@@ -90,43 +90,51 @@ defmodule DecoderTest do
   test "parses strings unless they contain unfinished escape sequences" do
     stream = Stream.map(["a,be", "\"c,d"], &(&1))
     assert_raise CorruptStreamError, fn ->
-      Decoder.decode(stream, headers: [:a, :b]) |> Enum.into([])
+      Decoder.decode!(stream, headers: [:a, :b]) |> Enum.into([])
     end
   end
 
   test "parses strings that contain multi-byte unicode characters" do
     stream = Stream.map(["a,b", "c,ಠ_ಠ"], &(&1))
-    result = CSV.decode(stream) |> Enum.into([])
+    result = CSV.decode!(stream) |> Enum.into([])
 
     assert result == [["a", "b"], ["c", "ಠ_ಠ"]]
   end
 
   test "produces meaningful errors for non-unicode files" do
     stream = "./fixtures/broken-encoding.csv" |> Path.expand(__DIR__) |> File.stream!
+
     assert_raise EncodingError, fn ->
-      CSV.decode(stream) |> Enum.into([]) |> Enum.sort
+      CSV.decode!(stream) |> Enum.into([]) |> Enum.sort
     end
+
+    assert CSV.decode(stream)
+    |> Enum.into([])
+    |> Enum.any?(fn
+      { :error, EncodingError, _, _ } -> true
+      _ -> false
+    end)
   end
 
   test "discards any state in the current message queues when halted" do
     stream = Stream.map(["a,be", "c,d", "e,f", "g,h", "i,j", "k,l"], &(&1))
-    result = Decoder.decode(stream) |> Enum.take(2)
+    result = Decoder.decode!(stream) |> Enum.take(2)
 
     assert result == [~w(a be), ~w(c d)]
 
-    next_result = Decoder.decode(stream) |> Enum.take(2)
+    next_result = Decoder.decode!(stream) |> Enum.take(2)
     assert next_result == [~w(a be), ~w(c d)]
   end
 
   test "empty stream input produces an empty stream as output" do
     stream = Stream.map([], &(&1))
-              |> Decoder.decode
+              |> Decoder.decode!
     assert stream |> Enum.into([]) == []
   end
 
   test "can reuse the same stream" do
     stream = Stream.map(["a,be", "c,d", "e,f", "g,h", "i,j", "k,l"], &(&1))
-             |> Decoder.decode
+             |> Decoder.decode!
     result = stream |> Enum.take(2)
 
     assert result == [~w(a be), ~w(c d)]
@@ -137,14 +145,14 @@ defmodule DecoderTest do
 
   test "delivers the correct number of rows" do
     stream = Stream.map(["a,be", "c,d", "e,f", "g,h", "i,j", "k,l"], &(&1))
-    result = Decoder.decode(stream) |> Enum.count
+    result = Decoder.decode!(stream) |> Enum.count
 
     assert result == 6
   end
 
   test "collects rows with fields spanning multiple lines" do
     stream = Stream.map(["a,\"be", "c,d", "e,f\"", "g,h", "i,j", "k,l"], &(&1))
-    result = Decoder.decode(stream) |> Enum.take(2)
+    result = Decoder.decode!(stream) |> Enum.take(2)
 
     assert result == [["a", "be\r\nc,d\r\ne,f"], ~w(g h)]
   end
@@ -153,7 +161,7 @@ defmodule DecoderTest do
     stream = Stream.map([",ci,\"\"\"", ",c,d"], &(&1))
 
     assert_raise CorruptStreamError, fn ->
-      Decoder.decode(stream) |> Stream.run
+      Decoder.decode!(stream) |> Stream.run
     end
   end
 
@@ -185,7 +193,7 @@ defmodule DecoderTest do
       "\",\"\"\"\"",
     ], &(&1))
 
-    result = Decoder.decode(stream) |> Enum.into([])
+    result = Decoder.decode!(stream) |> Enum.into([])
 
     assert result == [
       [
@@ -226,16 +234,31 @@ defmodule DecoderTest do
     stream = Stream.map(["a,\"be", "c,d", "e,f\"", "g,h", "i,j", "k,l"], &(&1))
 
     assert_raise SyntaxError, fn ->
-      Decoder.decode(stream, multiline_escape: false) |> Stream.run
+      Decoder.decode!(stream, multiline_escape: false) |> Stream.run
     end
+
+    assert stream
+    |> Decoder.decode(multiline_escape: false)
+    |> Stream.filter(fn
+      { :error, SyntaxError, _, _ } -> true
+      _ -> false
+    end)
+    |> Enum.count == 2
   end
 
   test "raises an error if rows are of variable length" do
     stream = Stream.map(["a,\"be\"", ",c,d", "e,f", "g,,h", "i,j", "k,l"], &(&1))
 
     assert_raise RowLengthError, fn ->
-      Decoder.decode(stream) |> Stream.run
+      Decoder.decode!(stream) |> Stream.run
     end
+
+    assert stream
+    |> Decoder.decode
+    |> Stream.any(fn
+      { :error, RowLengthError, _, _ } -> true
+    _ -> false
+    end)
   end
 
   test "delivers correctly ordered rows" do
@@ -254,7 +277,7 @@ defmodule DecoderTest do
       "w,x",
       "y,z"
     ], &(&1))
-    result = Decoder.decode(stream, num_pipes: 3) |> Enum.into([])
+    result = Decoder.decode!(stream, num_pipes: 3) |> Enum.into([])
 
     assert result ==  [
       ~w(a be),
@@ -274,7 +297,7 @@ defmodule DecoderTest do
   end
 
   def encode_decode_loop(l) do
-    l |> CSV.encode |> CSV.decode |> Enum.to_list
+    l |> CSV.encode |> CSV.decode! |> Enum.to_list
   end
   test "does not get corrupted after an error" do
     assert_raise Protocol.UndefinedError, fn ->

--- a/test/decoder_test.exs
+++ b/test/decoder_test.exs
@@ -255,7 +255,7 @@ defmodule DecoderTest do
 
     assert stream
     |> Decoder.decode
-    |> Stream.any(fn
+    |> Enum.any?(fn
       { :error, RowLengthError, _, _ } -> true
     _ -> false
     end)

--- a/test/decoder_test.exs
+++ b/test/decoder_test.exs
@@ -115,7 +115,7 @@ defmodule DecoderTest do
     assert CSV.decode(stream)
     |> Enum.into([])
     |> Enum.any?(fn
-      { :error, EncodingError, _, _ } -> true
+      { :error, "Invalid encoding" } -> true
     _ -> false
     end)
   end
@@ -248,7 +248,7 @@ defmodule DecoderTest do
     assert stream
     |> Decoder.decode(multiline_escape: false)
     |> Stream.filter(fn
-      { :error, SyntaxError, _, _ } -> true
+      { :error, message } -> message |> String.contains?("Unterminated escape sequence")
     _ -> false
     end)
     |> Enum.count == 2
@@ -268,7 +268,7 @@ defmodule DecoderTest do
     assert stream
     |> Decoder.decode
     |> Enum.filter(fn
-      { :error, RowLengthError, _, _ } -> true
+      { :error, message } -> message |> String.contains?("row with length")
     _ -> false
     end)
     |> Enum.count == 2


### PR DESCRIPTION
Changes `decode` to return a stream of monads, and adds `decode!`, which behaves like `decode` used to (raise any occurring error, returning a stream of rows).

This is in order to resolve #28.

I apologize if I went overboard when refactoring to adjust to the requirements.

I'm particularly not happy with the `Enum.into(%{})` and `Enum.into([])` it uses to pass options around, but it seem to make all the other code more readable since the merging and reading syntax in a map is shorter and it allows us to pattern match. Any ideas are appreciated.