### PR TITLE
Fix typo in parse_bench

### DIFF
--- a/bench/parse_bench.exs
+++ b/bench/parse_bench.exs
@@ -1,4 +1,4 @@
-defmodult ParseBench do
+defmodule ParseBench do
   use Benchfella
 
   setup_all do


### PR DESCRIPTION
Fixes defmodult -> defmodule so that it runs.