### PR TITLE
CSV.decode_as_map

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ File.stream!("data.csv") |> CSV.decode_as_map
 ```
 create a stream of maps with the header as atom keys like this
 ```
-{a: 1, b: 2, c: 3}
-{a: 4, b: 5, c: 6}
+{a: "1", b: "2", c: "3"}
+{a: "4", b: "5", c: "6"}
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,29 @@ Enum.map(fn row ->
 end)
 ````
 
+### Decoding as a Map
+Given a `csv` with headers like this
+
+**data.csv**
+```
+a,b,c
+1,2,3
+4,5,6
+...
+```
+
+using `CSV.decode_as_map` you can decode the file as a stream of maps using the header. The following lines
+```elixir
+File.stream!("data.csv") |> CSV.decode_as_map
+```
+create a stream of maps with the header as atom keys like this
+```
+{a: 1, b: 2, c: 3}
+{a: 4, b: 5, c: 6}
+...
+```
+
+## Encoding 
 Do this to encode a table (two-dimensional list):
 
 ````elixir

--- a/lib/csv.ex
+++ b/lib/csv.ex
@@ -117,11 +117,11 @@ defmodule CSV do
   ...
   ```
 
-  using `CSV.decode_as_map` you can decode as a stream of `Map` using the header information such that
+  using `CSV.decode_as_map` you can decode the file as a stream of maps using the header. The following lines
   ```elixir
   File.stream!("data.csv") |> CSV.decode_as_map
   ```
-  should create a stream of maps with the header as atom keys
+  create a stream of maps with the header as atom keys like this
   ```
   {a: 1, b: 2, c: 3}
   {a: 4, b: 5, c: 6}

--- a/lib/csv.ex
+++ b/lib/csv.ex
@@ -105,4 +105,28 @@ defmodule CSV do
     CSV.Encoder.encode(stream, options)
   end
 
+
+  @doc """
+  Given a `csv` with headers like this
+
+  **data.csv**
+  ```
+  a,b,c
+  1,2,3
+  4,5,6
+  ...
+  ```
+
+  using `CSV.decode_as_map` you can decode as a stream of `Map` using the header information such that
+  ```elixir
+  File.stream!("data.csv") |> CSV.decode_as_map
+  ```
+  should create a stream of maps with the header as atom keys
+  ```
+  {a: 1, b: 2, c: 3}
+  {a: 4, b: 5, c: 6}
+  ...
+  ```
+  """
+
 end

--- a/lib/csv/decoder.ex
+++ b/lib/csv/decoder.ex
@@ -187,8 +187,8 @@ defmodule CSV.Decoder do
   defp simplify_error(monad), do: monad
 
 
-  
-  def decode_as_map(enum, options \\ []) do
+
+  def decode_as_map(enum, options) do
     enum
     |> CSV.decode(options)
     |> Stream.transform(:first, &structure_from_header/2)

--- a/lib/csv/decoder.ex
+++ b/lib/csv/decoder.ex
@@ -186,4 +186,32 @@ defmodule CSV.Decoder do
   end
   defp simplify_error(monad), do: monad
 
+
+  
+  def decode_as_map(enum, options \\ []) do
+    enum
+    |> CSV.decode(options)
+    |> Stream.transform(:first, &structure_from_header/2)
+    |> Stream.drop(1)
+  end
+
+  #The accumulator should initially be :first, the its set to the structure of the csv
+  #which is the first line
+  defp structure_from_header(line, :first) do
+    structure = line
+      |> Enum.map(&String.to_atom/1)
+    
+    { [ nil ], structure }
+  end
+
+  #zips the stucture and the current line into a map
+  defp structure_from_header(line, structure) do
+    map = 
+      structure
+      |> Enum.zip(line)
+      |> Enum.into(%{})
+
+    { [ map ], structure }
+  end
+
 end


### PR DESCRIPTION
Given a `csv` with headers like this

**data.csv**
```
a,b,c
1,2,3
4,5,6
...
```

using `CSV.decode_as_map` you can decode the file as a stream of maps using the header. The following lines
```elixir
File.stream!("data.csv") |> CSV.decode_as_map
```
create a stream of maps with the header as atom keys like this
```
{a: "1", b: "2", c: "3"}
{a: "4", b: "5", c: "6"}
...
```