### PR TITLE
Skip a defined amount of number of lines from the stream

### DIFF
--- a/test/decoder_test.exs
+++ b/test/decoder_test.exs
@@ -46,6 +46,22 @@ defmodule DecoderTest do
     ]
   end
 
+    test "decodes with headers from a StringIO stream and drop n lines" do
+    {:ok, out} =
+      "#comment1\n,#comment2\naa,bb,cc\nd,e,f\ng,h,i"
+      |> StringIO.open
+
+    result = out
+             |> IO.binstream(:line)
+             |> CSV.decode!(headers: true, drop_rows: 2)
+             |> Enum.into([])
+
+    assert result == [
+      %{"aa" => "d", "bb" => "e", "cc" => "f"},
+      %{"aa" => "g", "bb" => "h", "cc" => "i"}
+    ]
+  end
+
   test "parses strings into a list of token tuples and emits them" do
     stream = Stream.map(["a,be", "c,d"], &(&1))
     result = Decoder.decode!(stream) |> Enum.into([])


### PR DESCRIPTION
This patch enables us to skip/drop an amount of lines from the stream. 

This is a crucial issue for me when dealing with CSV's since I can't control the sender and some devices are producing files with extra lines(comments) at the top of the file, this patch enables us to skip those lines without affecting the parsing.

However, I do understand if this gets reject since is not RFC 4180 compliant CSV.