### PR TITLE
Make sure parallel_stream is started on app start

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,6 +18,10 @@ defmodule CSV.Mixfile do
     ]
   end
 
+  def application do
+    [applications: [:parallel_stream]]
+  end
+
   defp package do
     [
         maintainers: ["Beat Richartz"],


### PR DESCRIPTION
When deploying our application, we saw this error: `** (UndefinedFunctionError) undefined function ParallelStream.map/3 (module ParallelStream is not available)`

Since `csv` depends on `ParallelStream` at runtime, we need to add it to the applications list in `mix.exs`.