### PR TITLE
Remove useless lex private method

### DIFF
--- a/lib/csv/decoding/lexer.ex
+++ b/lib/csv/decoding/lexer.ex
@@ -50,9 +50,6 @@ defmodule CSV.Decoding.Lexer do
   defp lex(tokens, { :content, value }, << head :: utf8 >> <> tail, separator) do
     lex(tokens, { :content, value <> << head :: utf8 >> }, tail, separator)
   end
-  defp lex(tokens, nil, << head :: utf8 >> <> tail, separator) do
-    lex(tokens, { :content, << head :: utf8 >> }, tail, separator)
-  end
   defp lex(tokens, current_token, << head :: utf8 >> <> tail, separator) do
     lex(tokens |> add_token(current_token), { :content, << head :: utf8 >> }, tail, separator)
   end


### PR DESCRIPTION
Hi, I'm reading all the code to understand better this library and getting better in Elixir.

I saw that method is useless and remove it change nothing for the tests. The method following in the code `defp lex(tokens, current_token, << head :: utf8 >> <> tail, separator) ` cover the case when `current_token` is `nil` because you have the `defp add_token(tokens, nil)` function that does nothing if current_token is nil. So I think we can remove it for a better readability.

Cheers