### PR TITLE
Added :quoting option to CSV.decode method 

### DIFF
--- a/lib/csv.ex
+++ b/lib/csv.ex
@@ -18,6 +18,7 @@ defmodule CSV do
 
     * `:separator`   – The separator token to use, defaults to `?,`. Must be a codepoint (syntax: ? + (your separator)).
     * `:strip_fields` – When set to true, will strip whitespace from cells. Defaults to false.
+    * `:quoting` – When set to true, will remove double quotes from output. Defaults to true.
     * `:escape_max_lines` – How many lines to maximally aggregate for multiline escapes. Defaults to a 1000.
     * `:num_workers` – The number of parallel operations to run when producing the stream.
     * `:worker_work_ratio` – The available work per worker, defaults to 5. Higher rates will mean more work sharing, but might also lead to work fragmentation slowing down the queues.

--- a/lib/csv/decoding/decoder.ex
+++ b/lib/csv/decoding/decoder.ex
@@ -22,6 +22,7 @@ defmodule CSV.Decoding.Decoder do
 
     * `:separator`   – The separator token to use, defaults to `?,`. Must be a codepoint (syntax: ? + (your separator)).
     * `:strip_fields` – When set to true, will strip whitespace from fields. Defaults to false.
+    * `:quoting` – When set to true, will remove double quotes from output. Defaults to true.
     * `:escape_max_lines` – How many lines to maximally aggregate for multiline escapes. Defaults to a 1000.
     * `:num_workers` – The number of parallel operations to run when producing the stream.
     * `:worker_work_ratio` – The available work per worker, defaults to 5. Higher rates will mean more work sharing, but might also lead to work fragmentation slowing down the queues.

--- a/lib/csv/decoding/parser.ex
+++ b/lib/csv/decoding/parser.ex
@@ -15,6 +15,7 @@ defmodule CSV.Decoding.Parser do
   Options get transferred from the decoder. They are:
 
     * `:strip_fields` – When set to true, will strip whitespace from fields. Defaults to false.
+    * `:quoting` – When set to true, will remove double quotes from output. Defaults to true.
   """
 
   def parse(message, options \\ [])

--- a/lib/csv/decoding/parser.ex
+++ b/lib/csv/decoding/parser.ex
@@ -54,6 +54,7 @@ defmodule CSV.Decoding.Parser do
     end
   end
   defp parse(row, field, [token | tokens], false, after_unquote, options) do
+      quoting = options |> Keyword.get(:quoting, true)
     case token do
       {:content, content} ->
         parse(row, field <> content, tokens, false, false, options)
@@ -61,7 +62,7 @@ defmodule CSV.Decoding.Parser do
         parse(row ++ [field |> strip(options)], "", tokens, false, false, options)
       {:delimiter, _} ->
         parse(row, field, tokens, false, false, options)
-      {:double_quote, content} when after_unquote ->
+      {:double_quote, content} when after_unquote or not quoting ->
         parse(row, field <> content, tokens, true, false, options)
       {:double_quote, _} ->
         parse(row, field, tokens, true, false, options)

--- a/lib/csv/decoding/preprocessing/codepoints.ex
+++ b/lib/csv/decoding/preprocessing/codepoints.ex
@@ -21,11 +21,12 @@ defmodule CSV.Decoding.Preprocessing.Codepoints do
 
   def process(stream, options \\ []) do
     escape_max_lines = options |> Keyword.get(:escape_max_lines, @escape_max_lines)
+    quoting = options |> Keyword.get(:quoting, true)
 
     stream
         |> Stream.concat([@stream_end])
         |> Stream.transform(fn -> { "", nil, "", false, 0 } end, fn codepoint, line ->
-      collect_codepoint(line, escape_max_lines, codepoint)
+      collect_codepoint(line, escape_max_lines, codepoint, quoting)
     end, fn { _, _, escaped_part, escaped, num_lines } ->
       if escaped do
         raise EscapeSequenceError,
@@ -37,41 +38,44 @@ defmodule CSV.Decoding.Preprocessing.Codepoints do
     end)
   end
 
-  defp collect_codepoint({ _, _, escaped_part, true, num_lines }, escape_max_lines, << @newline :: utf8 >>) when escape_max_lines == num_lines do
+  defp collect_codepoint({ _, _, escaped_part, true, num_lines }, escape_max_lines, << @newline :: utf8 >>, _) when escape_max_lines == num_lines do
     raise EscapeSequenceError,
                  line: num_lines + 1,
                  escape_sequence: escaped_part,
                  escape_max_lines: escape_max_lines,
                  num_escaped_lines: num_lines
   end
-  defp collect_codepoint({ line, _, escaped_part, true, num_lines }, _, << @newline :: utf8 >>) do
+  defp collect_codepoint({ line, _, escaped_part, true, num_lines }, _, << @newline :: utf8 >>, _) do
     { [], { line <> << @newline :: utf8 >>, << @newline :: utf8 >>, escaped_part <> << @newline :: utf8 >>, true, num_lines + 1 } }
   end
-  defp collect_codepoint({ "", _, _, false, num_lines }, _, @stream_end) do
+  defp collect_codepoint({ "", _, _, false, num_lines }, _, @stream_end, _) do
     { [], { "", @stream_end, "", false, num_lines } }
   end
-  defp collect_codepoint({ line, _, _, false, num_lines }, _, @stream_end) do
+  defp collect_codepoint({ line, _, _, false, num_lines }, _, @stream_end, _) do
     { [line], { "", @stream_end, "", false, num_lines } }
   end
-  defp collect_codepoint({ line, _, _, false, num_lines }, _, << @carriage_return :: utf8 >>) do
+  defp collect_codepoint({ line, _, _, false, num_lines }, _, << @carriage_return :: utf8 >>, _) do
     { [line], { "", << @carriage_return :: utf8 >>, "", false, num_lines } }
   end
-  defp collect_codepoint({ _, << @carriage_return :: utf8 >>, _, false, num_lines }, _, << @newline :: utf8 >>) do
+  defp collect_codepoint({ _, << @carriage_return :: utf8 >>, _, false, num_lines }, _, << @newline :: utf8 >>, _) do
     { [], { "", << @newline :: utf8 >>, "", false, num_lines } }
   end
-  defp collect_codepoint({ line, _, _, false, num_lines }, _, << @newline :: utf8 >>) do
+  defp collect_codepoint({ line, _, _, false, num_lines }, _, << @newline :: utf8 >>, _) do
     { [line], { "", << @newline :: utf8 >>, "", false, num_lines } }
   end
-  defp collect_codepoint({ line, _, escaped_part, true, num_lines }, _, << @double_quote :: utf8 >>) do
+  defp collect_codepoint({ line, _, escaped_part, _, num_lines }, _, << @double_quote :: utf8 >>, false) do
     { [], { line <> << @double_quote :: utf8 >>, << @double_quote :: utf8 >>, escaped_part <> << @newline :: utf8 >>, false, num_lines } }
   end
-  defp collect_codepoint({ line, _, _, false, num_lines }, _, << @double_quote :: utf8 >>) do
+  defp collect_codepoint({ line, _, escaped_part, true, num_lines }, _, << @double_quote :: utf8 >>, true) do
+    { [], { line <> << @double_quote :: utf8 >>, << @double_quote :: utf8 >>, escaped_part <> << @newline :: utf8 >>, false, num_lines } }
+  end
+  defp collect_codepoint({ line, _, _, false, num_lines }, _, << @double_quote :: utf8 >>, true) do
     { [], { line <> << @double_quote :: utf8 >>, << @double_quote :: utf8 >>, "", true, num_lines } }
   end
-  defp collect_codepoint({ line, _, escaped_part, true, num_lines }, _, codepoint) do
+  defp collect_codepoint({ line, _, escaped_part, true, num_lines }, _, codepoint, _) do
     { [], { line <> codepoint, codepoint, escaped_part <> codepoint, true, num_lines } }
   end
-  defp collect_codepoint({ line, _, _, false, num_lines }, _, codepoint) do
+  defp collect_codepoint({ line, _, _, false, num_lines }, _, codepoint, _) do
     { [], { line <> codepoint, codepoint, "", false, num_lines } }
   end
 end


### PR DESCRIPTION
As far as sometimes CSV fields contains JSON or XML or whatever, removing all double quotes is resulting problems. So I've added 'quoting' option for decoder as in [python csv module ](https://docs.python.org/2.7/library/csv.html#dialects-and-formatting-parameters). 
I hope it'll be helpful.