### PR TITLE
Update parser.ex

### DIFF
--- a/lib/csv/decoding/parser.ex
+++ b/lib/csv/decoding/parser.ex
@@ -75,7 +75,7 @@ defmodule CSV.Decoding.Parser do
   defp strip(field, options) do
     strip_fields = options |> Keyword.get(:strip_fields, false)
     case strip_fields do
-      true -> field |> String.strip
+      true -> field |> String.trim
       _ -> field
     end
   end


### PR DESCRIPTION
Hi @beatrichartz ,

Thanks for the nice lib!
This PR is to fix the following warning.

```
==> csv
Compiling 10 files (.ex)
warning: String.strip/1 is deprecated, use String.trim/1
  lib/csv/decoding/parser.ex:78
```