### PR TITLE
Allow replacement of bad encoding

### DIFF
--- a/lib/csv/decoding/decoder.ex
+++ b/lib/csv/decoding/decoder.ex
@@ -38,6 +38,8 @@ defmodule CSV.Decoding.Decoder do
       When set to `false` (default), will use no header values.
       When set to anything but `false`, the resulting rows in the matrix will
       be maps instead of lists.
+  * `:replacer`   – The replacement string to use where lines have bad encoding
+      , defaults to `nil` which disables replacement.
 
   ## Examples
 

--- a/lib/csv/decoding/decoder.ex
+++ b/lib/csv/decoding/decoder.ex
@@ -38,8 +38,8 @@ defmodule CSV.Decoding.Decoder do
       When set to `false` (default), will use no header values.
       When set to anything but `false`, the resulting rows in the matrix will
       be maps instead of lists.
-  * `:replacer`   – The replacement string to use where lines have bad encoding
-      , defaults to `nil` which disables replacement.
+  * `:replacer`   – The replacement string to use where lines have bad
+      encoding. Defaults to `nil`, which disables replacement.
 
   ## Examples
 

--- a/lib/csv/decoding/decoder.ex
+++ b/lib/csv/decoding/decoder.ex
@@ -38,7 +38,7 @@ defmodule CSV.Decoding.Decoder do
       When set to `false` (default), will use no header values.
       When set to anything but `false`, the resulting rows in the matrix will
       be maps instead of lists.
-  * `:replacer`   – The replacement string to use where lines have bad
+  * `:replacement`   – The replacement string to use where lines have bad
       encoding. Defaults to `nil`, which disables replacement.
 
   ## Examples

--- a/lib/csv/decoding/lexer.ex
+++ b/lib/csv/decoding/lexer.ex
@@ -18,18 +18,18 @@ defmodule CSV.Decoding.Lexer do
     * `:separator`   – The separator token to use, defaults to `?,`. Must be a
       codepoint.
 
-    * `:replacer`    – The replacement string to use where lines have bad
+    * `:replacement`    – The replacement string to use where lines have bad
       encoding. Defaults to `nil`, which disables replacement.
   """
 
   def lex({ line, index }, options \\ []) when is_list(options) do
     separator = options |> Keyword.get(:separator, @separator)
-    replacer = options |> Keyword.get(:replacer, @replacer)
+    replacement = options |> Keyword.get(:replacement, @replacement)
 
     case String.valid?(line) do
       false ->
-        if replacer do
-          replace_bad_encoding(line, replacer) |> lex(index, separator)
+        if replacement do
+          replace_bad_encoding(line, replacement) |> lex(index, separator)
         else
           { :error, EncodingError, "Invalid encoding", index }
         end
@@ -78,10 +78,10 @@ defmodule CSV.Decoding.Lexer do
     tokens ++ [token]
   end
 
-  defp replace_bad_encoding(line, replacer) do
+  defp replace_bad_encoding(line, replacement) do
     line
     |> String.codepoints
-    |> Enum.map(fn codepoint -> if String.valid?(codepoint), do: codepoint, else: replacer end)
+    |> Enum.map(fn codepoint -> if String.valid?(codepoint), do: codepoint, else: replacement end)
     |> Enum.join
   end
 end

--- a/lib/csv/decoding/lexer.ex
+++ b/lib/csv/decoding/lexer.ex
@@ -18,7 +18,7 @@ defmodule CSV.Decoding.Lexer do
     * `:separator`   – The separator token to use, defaults to `?,`. Must be a
       codepoint.
 
-    * `:replacer`    – The replacement string to use when replacing bad
+    * `:replacer`    – The replacement string to use where lines have bad
       encoding. Defaults to `nil`, which disables replacement.
   """
 

--- a/lib/csv/decoding/lexer.ex
+++ b/lib/csv/decoding/lexer.ex
@@ -17,13 +17,22 @@ defmodule CSV.Decoding.Lexer do
 
     * `:separator`   – The separator token to use, defaults to `?,`. Must be a
       codepoint.
+
+    * `:replacer`    – The replacement string to use when replacing bad
+      encoding. Defaults to `nil`, which disables replacement.
   """
 
   def lex({ line, index }, options \\ []) when is_list(options) do
     separator = options |> Keyword.get(:separator, @separator)
+    replacer = options |> Keyword.get(:replacer, @replacer)
 
     case String.valid?(line) do
-      false -> { :error, EncodingError, "Invalid encoding", index }
+      false ->
+        if replacer do
+          replace_bad_encoding(line, replacer) |> lex(index, separator)
+        else
+          { :error, EncodingError, "Invalid encoding", index }
+        end
       true -> lex(line, index, separator)
     end
   end
@@ -67,5 +76,12 @@ defmodule CSV.Decoding.Lexer do
   end
   defp add_token(tokens, token) do
     tokens ++ [token]
+  end
+
+  defp replace_bad_encoding(line, replacer) do
+    line
+    |> String.codepoints
+    |> Enum.map(fn codepoint -> if String.valid?(codepoint), do: codepoint, else: replacer end)
+    |> Enum.join
   end
 end

--- a/lib/csv/defaults.ex
+++ b/lib/csv/defaults.ex
@@ -11,6 +11,7 @@ defmodule CSV.Defaults do
       @delimiter          << @carriage_return :: utf8 >> <> << @newline :: utf8 >>
       @double_quote       ?"
       @escape_max_lines   1000
+      @replacer           nil
     end
   end
 

--- a/lib/csv/defaults.ex
+++ b/lib/csv/defaults.ex
@@ -11,7 +11,7 @@ defmodule CSV.Defaults do
       @delimiter          << @carriage_return :: utf8 >> <> << @newline :: utf8 >>
       @double_quote       ?"
       @escape_max_lines   1000
-      @replacement           nil
+      @replacement        nil
     end
   end
 

--- a/lib/csv/defaults.ex
+++ b/lib/csv/defaults.ex
@@ -11,7 +11,7 @@ defmodule CSV.Defaults do
       @delimiter          << @carriage_return :: utf8 >> <> << @newline :: utf8 >>
       @double_quote       ?"
       @escape_max_lines   1000
-      @replacer           nil
+      @replacement           nil
     end
   end
 

--- a/test/decoding/baseline_exceptions_test.exs
+++ b/test/decoding/baseline_exceptions_test.exs
@@ -13,12 +13,33 @@ defmodule DecodingTests.BaselineExceptionsTest do
     end)
   end
 
+  defp filter_nonerrors(stream) do
+    stream |> Stream.filter(fn
+      { :error, _, _, _ } -> false
+      _ -> true
+    end)
+  end
+
   test "produces meaningful errors for non-unicode files" do
     stream = "../fixtures/broken-encoding.csv" |> Path.expand(__DIR__) |> File.stream!
 
     errors = stream |> Decoder.decode |> filter_errors |> Enum.to_list
     assert errors == [
       {:error, EncodingError, "Invalid encoding", 0}
+    ]
+  end
+
+  test "invalid encoding can be replaced" do
+    stream = "../fixtures/broken-encoding.csv" |> Path.expand(__DIR__) |> File.stream!
+
+    errors = stream |> Decoder.decode(replacer: "?") |> filter_errors |> Enum.to_list
+    assert errors != [
+      {:error, EncodingError, "Invalid encoding", 0}
+    ]
+
+    nonerrors = stream |> Decoder.decode(replacer: "?") |> filter_nonerrors |> Enum.to_list
+    assert nonerrors == [
+      {:ok, ~w(a b c d e c ?_?)}
     ]
   end
 

--- a/test/decoding/baseline_exceptions_test.exs
+++ b/test/decoding/baseline_exceptions_test.exs
@@ -24,7 +24,7 @@ defmodule DecodingTests.BaselineExceptionsTest do
 
   test "invalid encoding can be replaced" do
     stream = [<<"a,", 255>>, "c,d"] |> to_stream
-    result = Decoder.decode(stream, replacer: "?") |> Enum.take(2)
+    result = Decoder.decode(stream, replacement: "?") |> Enum.take(2)
 
     assert result == [ok: ~w(a ?), ok: ~w(c d)]
   end


### PR DESCRIPTION
When processing CSV files we may encounter fields which are
poorly encoded. These fields may not be of concern to the
task at hand and such bad encoding can be ignored.

Herein an option `:replacement` is introduced, the value of which
is used to replace bad codepoints. It defaults to `nil` which disables
any replacement.