### PR TITLE
Fix deprecations from new hex version

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lib/csv.ex
+++ b/lib/csv.ex
@@ -184,6 +184,7 @@ defmodule CSV do
     case options |> Keyword.get(:preprocessor) do
       :none ->
         stream |> Preprocessing.None.process(options)
+
       _ ->
         stream |> Preprocessing.Lines.process(options)
     end
@@ -195,13 +196,18 @@ defmodule CSV do
     stream |> Stream.map(&yield_or_raise!(&1, escape_max_lines))
   end
 
-  defp yield_or_raise!({ :error, EscapeSequenceError, escape_sequence, index }, escape_max_lines) do
-    raise EscapeSequenceError, escape_sequence: escape_sequence, line: index + 1, escape_max_lines: escape_max_lines 
+  defp yield_or_raise!({:error, EscapeSequenceError, escape_sequence, index}, escape_max_lines) do
+    raise EscapeSequenceError,
+      escape_sequence: escape_sequence,
+      line: index + 1,
+      escape_max_lines: escape_max_lines
   end
-  defp yield_or_raise!({ :error, mod, message, index }, _) do
+
+  defp yield_or_raise!({:error, mod, message, index}, _) do
     raise mod, message: message, line: index + 1
   end
-  defp yield_or_raise!({ :ok, row }, _), do: row
+
+  defp yield_or_raise!({:ok, row}, _), do: row
 
   defp inline_errors!(stream, options) do
     escape_max_lines = options |> Keyword.get(:escape_max_lines, @escape_max_lines)
@@ -209,12 +215,19 @@ defmodule CSV do
     stream |> Stream.map(&yield_or_inline!(&1, escape_max_lines))
   end
 
-  defp yield_or_inline!({ :error, EscapeSequenceError, escape_sequence, index }, escape_max_lines) do
-    { :error, EscapeSequenceError.exception(escape_sequence: escape_sequence, line: index + 1, escape_max_lines: escape_max_lines).message }
+  defp yield_or_inline!({:error, EscapeSequenceError, escape_sequence, index}, escape_max_lines) do
+    {:error,
+     EscapeSequenceError.exception(
+       escape_sequence: escape_sequence,
+       line: index + 1,
+       escape_max_lines: escape_max_lines
+     ).message}
   end
-  defp yield_or_inline!({ :error, errormod, message, index }, _) do
-    { :error, errormod.exception(message: message, line: index + 1).message }
+
+  defp yield_or_inline!({:error, errormod, message, index}, _) do
+    {:error, errormod.exception(message: message, line: index + 1).message}
   end
+
   defp yield_or_inline!(value, _), do: value
 
   @doc """
@@ -251,5 +264,4 @@ defmodule CSV do
   def encode(stream, options \\ []) do
     Encoder.encode(stream, options)
   end
-
 end

--- a/lib/csv/decoding/parser.ex
+++ b/lib/csv/decoding/parser.ex
@@ -19,63 +19,79 @@ defmodule CSV.Decoding.Parser do
   """
 
   def parse(message, options \\ [])
-  def parse({ tokens, index }, options) do
+
+  def parse({tokens, index}, options) do
     case parse([], "", tokens, false, false, options) do
-      { :ok, row } -> { :ok, row, index }
-      { :error, type, message } -> { :error, type, message, index }
+      {:ok, row} -> {:ok, row, index}
+      {:error, type, message} -> {:error, type, message, index}
     end
   end
-  def parse({ :error, mod, message, index }, _) do
-    { :error, mod, message, index }
+
+  def parse({:error, mod, message, index}, _) do
+    {:error, mod, message, index}
   end
 
   defp parse(row, field, [token | tokens], true, _, options) do
     case token do
       {:double_quote, _} ->
         parse(row, field, tokens, false, true, options)
+
       {_, content} ->
         parse(row, field <> content, tokens, true, false, options)
     end
   end
+
   defp parse(_, field, [], true, _, _) do
-    { :error, EscapeSequenceError, field }
+    {:error, EscapeSequenceError, field}
   end
+
   defp parse(row, "", [token | tokens], false, after_unquote, options) do
     case token do
       {:content, content} ->
         parse(row, content, tokens, false, false, options)
+
       {:separator, _} ->
         parse(row ++ [""], "", tokens, false, false, options)
+
       {:delimiter, _} ->
         parse(row, "", tokens, false, false, options)
+
       {:double_quote, content} when after_unquote ->
         parse(row, content, tokens, true, false, options)
+
       {:double_quote, _} ->
         parse(row, "", tokens, true, false, options)
     end
   end
+
   defp parse(row, field, [token | tokens], false, after_unquote, options) do
     case token do
       {:content, content} ->
         parse(row, field <> content, tokens, false, false, options)
+
       {:separator, _} ->
         parse(row ++ [field |> strip(options)], "", tokens, false, false, options)
+
       {:delimiter, _} ->
         parse(row, field, tokens, false, false, options)
+
       {:double_quote, content} when after_unquote ->
         parse(row, field <> content, tokens, true, false, options)
+
       {:double_quote, _} ->
         parse(row, field, tokens, true, false, options)
     end
   end
+
   defp parse(row, field, [], false, _, options) do
-    { :ok, row ++ [field |> strip(options)] }
+    {:ok, row ++ [field |> strip(options)]}
   end
 
   defp strip(field, options) do
     strip_fields = options |> Keyword.get(:strip_fields, false)
+
     case strip_fields do
-      true -> field |> String.trim
+      true -> field |> String.trim()
       _ -> field
     end
   end

--- a/lib/csv/decoding/preprocessing/lines.ex
+++ b/lib/csv/decoding/preprocessing/lines.ex
@@ -18,41 +18,62 @@ defmodule CSV.Decoding.Preprocessing.Lines do
     escaped field
   """
 
-def process(stream, options \\ []) do
-    stream |>
-    Stream.concat([:stream_end]) |>
-    d_process(options)
+  def process(stream, options \\ []) do
+    stream
+    |> Stream.concat([:stream_end])
+    |> d_process(options)
   end
 
   defp d_process(stream, options) do
     separator = options |> Keyword.get(:separator, @separator)
     escape_max_lines = options |> Keyword.get(:escape_max_lines, @escape_max_lines)
 
-    stream |>
-    Stream.with_index |>
-    Stream.transform(
-      fn -> { [], "", 0, 0 } end,
+    stream
+    |> Stream.with_index()
+    |> Stream.transform(
+      fn -> {[], "", 0, 0} end,
       &do_process(&1, &2, separator, escape_max_lines),
-      fn _ -> :ok end)
+      fn _ -> :ok end
+    )
   end
-  defp do_process({ :stream_end, _ }, { escaped_lines, _, _, _ }, _, _) do
-    { escaped_lines, { [], "", 0, 0 } }
+
+  defp do_process({:stream_end, _}, {escaped_lines, _, _, _}, _, _) do
+    {escaped_lines, {[], "", 0, 0}}
   end
-  defp do_process({ line, line_index }, { [], _, _, _ }, separator, _) do
+
+  defp do_process({line, line_index}, {[], _, _, _}, separator, _) do
     start_sequence(line, line_index, separator)
   end
-  defp do_process({ line, line_index }, { escaped_lines, sequence_start, sequence_start_index, num_escaped_lines }, separator, escape_max_lines) when num_escaped_lines < escape_max_lines do
-    continue_sequence(escaped_lines, num_escaped_lines + 1, line, line_index, separator, sequence_start, sequence_start_index)
+
+  defp do_process(
+         {line, line_index},
+         {escaped_lines, sequence_start, sequence_start_index, num_escaped_lines},
+         separator,
+         escape_max_lines
+       )
+       when num_escaped_lines < escape_max_lines do
+    continue_sequence(
+      escaped_lines,
+      num_escaped_lines + 1,
+      line,
+      line_index,
+      separator,
+      sequence_start,
+      sequence_start_index
+    )
   end
-  defp do_process({ line, _ }, { escaped_lines, _, _, _ }, separator, escape_max_lines) do
+
+  defp do_process({line, _}, {escaped_lines, _, _, _}, separator, escape_max_lines) do
     reprocess(escaped_lines ++ [line], separator, escape_max_lines)
   end
 
   defp reprocess(lines, separator, escape_max_lines) do
-    [ corrupt_line | potentially_valid_lines ] = lines
-    { processed_lines, continuation } = potentially_valid_lines |>
-                                        Stream.with_index |>
-                                        Enum.flat_map_reduce({ [], "", 0, 0 }, &do_process(&1, &2, separator, escape_max_lines))
+    [corrupt_line | potentially_valid_lines] = lines
+
+    {processed_lines, continuation} =
+      potentially_valid_lines
+      |> Stream.with_index()
+      |> Enum.flat_map_reduce({[], "", 0, 0}, &do_process(&1, &2, separator, escape_max_lines))
 
     {
       [corrupt_line] ++ processed_lines,
@@ -61,21 +82,36 @@ def process(stream, options \\ []) do
   end
 
   defp start_sequence(line, line_index, separator) do
-    { starts_sequence, sequence_start } = starts_sequence?(line, separator)
+    {starts_sequence, sequence_start} = starts_sequence?(line, separator)
+
     cond do
       starts_sequence ->
-        { [], { [line], sequence_start, line_index, 1 } }
+        {[], {[line], sequence_start, line_index, 1}}
+
       true ->
-        { [line], { [], "", 0, 0 } }
+        {[line], {[], "", 0, 0}}
     end
   end
-  defp continue_sequence(escaped_lines, num_escaped_lines, line, line_index, separator, sequence_start, sequence_start_index) do
-    { ends_sequence, _ } = ends_sequence?(line, separator)
+
+  defp continue_sequence(
+         escaped_lines,
+         num_escaped_lines,
+         line,
+         line_index,
+         separator,
+         sequence_start,
+         sequence_start_index
+       ) do
+    {ends_sequence, _} = ends_sequence?(line, separator)
+
     cond do
       ends_sequence ->
-        start_sequence(escaped_lines ++ [line] |> Enum.join(@delimiter), line_index, separator)
+        start_sequence((escaped_lines ++ [line]) |> Enum.join(@delimiter), line_index, separator)
+
       true ->
-        { [], { escaped_lines ++ [line], sequence_start <> @delimiter <> line, sequence_start_index, num_escaped_lines } }
+        {[],
+         {escaped_lines ++ [line], sequence_start <> @delimiter <> line, sequence_start_index,
+          num_escaped_lines}}
     end
   end
 
@@ -83,36 +119,44 @@ def process(stream, options \\ []) do
     ends_sequence?(line, "", true, separator)
   end
 
-  defp ends_sequence?(<< @double_quote :: utf8 >> <> tail, _, quoted, separator) do
-    ends_sequence?(tail, << @double_quote :: utf8 >>, !quoted, separator)
+  defp ends_sequence?(<<@double_quote::utf8>> <> tail, _, quoted, separator) do
+    ends_sequence?(tail, <<@double_quote::utf8>>, !quoted, separator)
   end
-  defp ends_sequence?(<< head :: utf8 >> <> tail, _, quoted, separator) do
-    ends_sequence?(tail, << head :: utf8 >>, quoted, separator)
+
+  defp ends_sequence?(<<head::utf8>> <> tail, _, quoted, separator) do
+    ends_sequence?(tail, <<head::utf8>>, quoted, separator)
   end
+
   defp ends_sequence?("", _, quoted, _) do
-    { !quoted, "" }
+    {!quoted, ""}
   end
 
   defp starts_sequence?(line, separator) do
     starts_sequence?(line, "", false, separator, "")
   end
-  defp starts_sequence?(<< @double_quote :: utf8 >> <> tail, last_token, false, separator, _) when last_token == << separator :: utf8 >> do
+
+  defp starts_sequence?(<<@double_quote::utf8>> <> tail, last_token, false, separator, _)
+       when last_token == <<separator::utf8>> do
     starts_sequence?(tail, @double_quote, true, separator, tail)
-  end
-  defp starts_sequence?(<< @double_quote :: utf8 >> <> tail, "", false, separator, _) do
-    starts_sequence?(tail, @double_quote, true, separator, tail)
-  end
-  defp starts_sequence?(<< @double_quote :: utf8 >> <> tail, _, quoted, separator, sequence_start) do
-    starts_sequence?(tail, @double_quote, !quoted, separator, sequence_start)
-  end
-  defp starts_sequence?(<< head :: utf8 >> <> tail, _, quoted, separator, sequence_start) do
-    starts_sequence?(tail, << head :: utf8 >>, quoted, separator, sequence_start)
-  end
-  defp starts_sequence?(<< head >> <> tail, _, quoted, separator, sequence_start) do
-    starts_sequence?(tail, << head >>, quoted, separator, sequence_start)
-  end
-  defp starts_sequence?("", _, quoted, _, sequence_start) do
-    { quoted, sequence_start }
   end
 
+  defp starts_sequence?(<<@double_quote::utf8>> <> tail, "", false, separator, _) do
+    starts_sequence?(tail, @double_quote, true, separator, tail)
+  end
+
+  defp starts_sequence?(<<@double_quote::utf8>> <> tail, _, quoted, separator, sequence_start) do
+    starts_sequence?(tail, @double_quote, !quoted, separator, sequence_start)
+  end
+
+  defp starts_sequence?(<<head::utf8>> <> tail, _, quoted, separator, sequence_start) do
+    starts_sequence?(tail, <<head::utf8>>, quoted, separator, sequence_start)
+  end
+
+  defp starts_sequence?(<<head>> <> tail, _, quoted, separator, sequence_start) do
+    starts_sequence?(tail, <<head>>, quoted, separator, sequence_start)
+  end
+
+  defp starts_sequence?("", _, quoted, _, sequence_start) do
+    {quoted, sequence_start}
+  end
 end

--- a/lib/csv/decoding/preprocessing/none.ex
+++ b/lib/csv/decoding/preprocessing/none.ex
@@ -12,5 +12,4 @@ defmodule CSV.Decoding.Preprocessing.None do
   def process(stream, _ \\ []) do
     stream
   end
-
 end

--- a/lib/csv/defaults.ex
+++ b/lib/csv/defaults.ex
@@ -5,13 +5,13 @@ defmodule CSV.Defaults do
 
   defmacro __using__(_) do
     quote do
-      @separator          ?,
-      @newline            ?\n
-      @carriage_return    ?\r
-      @delimiter          << @carriage_return :: utf8 >> <> << @newline :: utf8 >>
-      @double_quote       ?"
-      @escape_max_lines   1000
-      @replacement        nil
+      @separator ?,
+      @newline ?\n
+      @carriage_return ?\r
+      @delimiter <<@carriage_return::utf8>> <> <<@newline::utf8>>
+      @double_quote ?"
+      @escape_max_lines 1000
+      @replacement nil
     end
   end
 
@@ -28,5 +28,4 @@ defmodule CSV.Defaults do
   def num_workers do
     :erlang.system_info(:schedulers) * 3
   end
-
 end

--- a/lib/csv/encoding/encode.ex
+++ b/lib/csv/encoding/encode.ex
@@ -36,26 +36,29 @@ defimpl CSV.Encode, for: BitString do
 
     cond do
       String.contains?(data, [
-        << separator :: utf8 >>,
+        <<separator::utf8>>,
         delimiter,
-        << @carriage_return :: utf8 >>,
-        << @newline :: utf8 >>,
-        << @double_quote :: utf8 >>
+        <<@carriage_return::utf8>>,
+        <<@newline::utf8>>,
+        <<@double_quote::utf8>>
       ]) ->
-        << @double_quote :: utf8 >> <>
-      (data |> escape |> String.replace(
-        << @double_quote :: utf8 >>,
-        << @double_quote :: utf8 >> <> << @double_quote :: utf8 >>)) <>
-        << @double_quote :: utf8 >>
+        <<@double_quote::utf8>> <>
+          (data
+           |> escape
+           |> String.replace(
+             <<@double_quote::utf8>>,
+             <<@double_quote::utf8>> <> <<@double_quote::utf8>>
+           )) <> <<@double_quote::utf8>>
+
       true ->
         data |> escape
     end
   end
 
   defp escape(cell) do
-    cell |>
-      String.replace(<< @newline :: utf8 >>, "\\n") |>
-      String.replace(<< @carriage_return :: utf8 >>, "\\r") |>
-      String.replace("\t", "\\t")
+    cell
+    |> String.replace(<<@newline::utf8>>, "\\n")
+    |> String.replace(<<@carriage_return::utf8>>, "\\r")
+    |> String.replace("\t", "\\t")
   end
 end

--- a/lib/csv/encoding/encoder.ex
+++ b/lib/csv/encoding/encoder.ex
@@ -57,14 +57,23 @@ defmodule CSV.Encoding.Encoder do
   end
 
   defp encode_stream(stream, false, options) do
-    stream |> Stream.transform(0, fn row, acc ->
-      {[encode_row(row, options)], acc + 1} end)
+    stream
+    |> Stream.transform(0, fn row, acc ->
+      {[encode_row(row, options)], acc + 1}
+    end)
   end
+
   defp encode_stream(stream, headers, options) do
-    stream |> Stream.transform(0, fn
-      row, 0 -> {[encode_row(get_headers(row, headers), options),
-                  encode_row(get_values(row, headers), options)], 1}
-      row, acc -> {[encode_row(get_values(row, headers), options)], acc + 1}
+    stream
+    |> Stream.transform(0, fn
+      row, 0 ->
+        {[
+           encode_row(get_headers(row, headers), options),
+           encode_row(get_values(row, headers), options)
+         ], 1}
+
+      row, acc ->
+        {[encode_row(get_values(row, headers), options)], acc + 1}
     end)
   end
 
@@ -78,9 +87,10 @@ defmodule CSV.Encoding.Encoder do
     separator = options |> Keyword.get(:separator, @separator)
     delimiter = options |> Keyword.get(:delimiter, @delimiter)
 
-    encoded = row
+    encoded =
+      row
       |> Enum.map(&encode_cell(&1, separator, delimiter))
-      |> Enum.join(<< separator :: utf8 >>)
+      |> Enum.join(<<separator::utf8>>)
 
     encoded <> delimiter
   end
@@ -88,5 +98,4 @@ defmodule CSV.Encoding.Encoder do
   defp encode_cell(cell, separator, delimiter) do
     CSV.Encode.encode(cell, separator: separator, delimiter: delimiter)
   end
-
 end

--- a/lib/csv/exceptions.ex
+++ b/lib/csv/exceptions.ex
@@ -6,7 +6,7 @@ defmodule CSV.EncodingError do
   defexception [:line, :message]
 
   def exception(options) do
-    line    = options |> Keyword.fetch!(:line)
+    line = options |> Keyword.fetch!(:line)
     message = options |> Keyword.fetch!(:message)
 
     %__MODULE__{
@@ -24,7 +24,7 @@ defmodule CSV.RowLengthError do
   defexception [:line, :message]
 
   def exception(options) do
-    line    = options |> Keyword.fetch!(:line)
+    line = options |> Keyword.fetch!(:line)
     message = options |> Keyword.fetch!(:message)
 
     %__MODULE__{
@@ -46,7 +46,8 @@ defmodule CSV.EscapeSequenceError do
     escape_sequence = options |> Keyword.fetch!(:escape_sequence)
     escape_max_lines = options |> Keyword.fetch!(:escape_max_lines)
 
-    message = "Escape sequence started on line #{line} " <>
+    message =
+      "Escape sequence started on line #{line} " <>
         "near \"#{escape_sequence |> String.slice(0..9)}\" did not terminate.\n\n" <>
         "Escape sequences are allowed to span up to #{escape_max_lines} lines. " <>
         "This threshold avoids collecting the whole file into memory " <>

--- a/mix.exs
+++ b/mix.exs
@@ -3,24 +3,24 @@ defmodule CSV.Mixfile do
 
   def project do
     [
-        app: :csv,
-        version: "2.1.1",
-        elixir: "~> 1.1",
-        deps: deps(),
-        package: package(),
-        docs: &docs/0,
-        name: "CSV",
-        consolidate_protocols: true,
-        source_url: "https://github.com/beatrichartz/csv",
-        description: "CSV Decoding and Encoding for Elixir",
-        elixirc_paths: elixirc_paths(),
-        test_coverage: [tool: ExCoveralls],
-        preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test]
+      app: :csv,
+      version: "2.1.1",
+      elixir: "~> 1.1",
+      deps: deps(),
+      package: package(),
+      docs: &docs/0,
+      name: "CSV",
+      consolidate_protocols: true,
+      source_url: "https://github.com/beatrichartz/csv",
+      description: "CSV Decoding and Encoding for Elixir",
+      elixirc_paths: elixirc_paths(),
+      test_coverage: [tool: ExCoveralls],
+      preferred_cli_env: [coveralls: :test, "coveralls.detail": :test, "coveralls.post": :test]
     ]
   end
 
   defp elixirc_paths do
-    if Mix.env == :test do
+    if Mix.env() == :test do
       ["lib", "test/support"]
     else
       ["lib"]
@@ -33,9 +33,9 @@ defmodule CSV.Mixfile do
 
   defp package do
     [
-        maintainers: ["Beat Richartz"],
-        licenses: ["MIT"],
-        links: %{github: "https://github.com/beatrichartz/csv" }
+      maintainers: ["Beat Richartz"],
+      licenses: ["MIT"],
+      links: %{github: "https://github.com/beatrichartz/csv"}
     ]
   end
 
@@ -57,8 +57,8 @@ defmodule CSV.Mixfile do
     {ref, 0} = System.cmd("git", ["rev-parse", "--verify", "--quiet", "HEAD"])
 
     [
-        source_ref: ref,
-        main: "CSV"
+      source_ref: ref,
+      main: "CSV"
     ]
   end
 end

--- a/test/csv_exceptions_test.exs
+++ b/test/csv_exceptions_test.exs
@@ -6,20 +6,20 @@ defmodule CSVExceptionsTest do
 
   test "decodes in normal mode emitting errors with rows" do
     stream = ~w(a,be a c,d) |> to_stream
-    result = CSV.decode(stream) |> Enum.to_list
+    result = CSV.decode(stream) |> Enum.to_list()
+
     assert result == [
-      ok: ~w(a be),
-      error: "Row has length 1 - expected length 2 on line 2",
-      ok: ~w(c d)
-    ]
+             ok: ~w(a be),
+             error: "Row has length 1 - expected length 2 on line 2",
+             ok: ~w(c d)
+           ]
   end
 
   test "decodes in strict mode raising errors" do
     stream = ~w(a,be a c,d) |> to_stream
 
     assert_raise RowLengthError, fn ->
-      CSV.decode!(stream) |> Stream.run
+      CSV.decode!(stream) |> Stream.run()
     end
   end
-
 end

--- a/test/csv_test.exs
+++ b/test/csv_test.exs
@@ -12,38 +12,48 @@ defmodule CSVTest do
 
   test "decodes in strict mode emitting rows as lists" do
     stream = ~w(a,be c,d) |> to_stream
-    result = CSV.decode!(stream) |> Enum.to_list
+    result = CSV.decode!(stream) |> Enum.to_list()
     assert result == [~w(a be), ~w(c d)]
   end
 
   test "decodes in normal mode emitting tuples containing rows" do
     stream = ~w(a,be c,d) |> to_stream
-    result = CSV.decode(stream) |> Enum.to_list
+    result = CSV.decode(stream) |> Enum.to_list()
+
     assert result == [
-      ok: ~w(a be),
-      ok: ~w(c d),
-    ]
+             ok: ~w(a be),
+             ok: ~w(c d)
+           ]
   end
 
   test "uses the :lines preprocessor by default" do
     stream = ~w(g,"h i,j" k,l) |> to_stream
-    result = CSV.decode(stream) |> Enum.to_list
+    result = CSV.decode(stream) |> Enum.to_list()
+
     assert result == [
-      ok: ["g", "h\r\ni,j"],
-      ok: ["k", "l"],
-    ]
+             ok: ["g", "h\r\ni,j"],
+             ok: ["k", "l"]
+           ]
   end
 
   test "uses the :none preprocessor if specified" do
     stream = ~w(g,"h i,j" k,l) |> to_stream
-    result = CSV.decode(stream, preprocessor: :none) |> Enum.to_list
-    assert result == [
-      error: CSV.EscapeSequenceError.exception(escape_sequence: "h", line: 1,
-                                               escape_max_lines: @escape_max_lines).message,
-      error: CSV.EscapeSequenceError.exception(escape_sequence: "j", line: 2,
-                                               escape_max_lines: @escape_max_lines).message,
-      ok: ["k", "l"]
-    ]
-  end
+    result = CSV.decode(stream, preprocessor: :none) |> Enum.to_list()
 
+    assert result == [
+             error:
+               CSV.EscapeSequenceError.exception(
+                 escape_sequence: "h",
+                 line: 1,
+                 escape_max_lines: @escape_max_lines
+               ).message,
+             error:
+               CSV.EscapeSequenceError.exception(
+                 escape_sequence: "j",
+                 line: 2,
+                 escape_max_lines: @escape_max_lines
+               ).message,
+             ok: ["k", "l"]
+           ]
+  end
 end

--- a/test/decoding/baseline_test.exs
+++ b/test/decoding/baseline_test.exs
@@ -8,80 +8,81 @@ defmodule DecodingTests.BaselineTest do
 
   test "parses lines into a list of fields" do
     stream = ["a,be", "c,d"] |> to_stream
-    result = Decoder.decode(stream) |> Enum.to_list
+    result = Decoder.decode(stream) |> Enum.to_list()
 
     assert result == [ok: ~w(a be), ok: ~w(c d)]
   end
 
   test "parses empty lines into a list of empty fields" do
     stream = [",", "c,d"] |> to_stream
-    result = Decoder.decode(stream) |> Enum.to_list
+    result = Decoder.decode(stream) |> Enum.to_list()
 
     assert result == [ok: ["", ""], ok: ~w(c d)]
   end
 
   test "parses partially populated lines into a list of fields" do
     stream = [",ci,\"\"", ",c,d"] |> to_stream
-    result = Decoder.decode(stream) |> Enum.to_list
+    result = Decoder.decode(stream) |> Enum.to_list()
 
     assert result == [ok: ["", "ci", ""], ok: ["", "c", "d"]]
   end
 
-
   test "parses strings that contain single double quotes" do
     stream = ["a,be", "\"c\"\"\",d"] |> to_stream
-    result = Decoder.decode(stream) |> Enum.to_list
+    result = Decoder.decode(stream) |> Enum.to_list()
 
     assert result == [ok: ["a", "be"], ok: ["c\"", "d"]]
   end
 
   test "parses strings that contain multi-byte unicode characters" do
     stream = ["a,b", "c,ಠ_ಠ"] |> to_stream
-    result = Decoder.decode(stream) |> Enum.to_list
+    result = Decoder.decode(stream) |> Enum.to_list()
 
     assert result == [ok: ["a", "b"], ok: ["c", "ಠ_ಠ"]]
   end
 
   test "delivers the correct number of rows" do
     stream = ["a,be", "c,d", "e,f", "g,h", "i,j", "k,l"] |> to_stream
-    result = Decoder.decode(stream) |> Enum.count
+    result = Decoder.decode(stream) |> Enum.count()
 
     assert result == 6
   end
 
   test "delivers correctly ordered rows" do
-    stream = [
-      "a,be",
-      "c,d",
-      "e,f",
-      "g,h",
-      "i,j",
-      "k,l",
-      "m,n",
-      "o,p",
-      "q,r",
-      "s,t",
-      "u,v",
-      "w,x",
-      "y,z"
-    ] |> to_stream
-    result = Decoder.decode(stream, num_workers: 3) |> Enum.to_list
+    stream =
+      [
+        "a,be",
+        "c,d",
+        "e,f",
+        "g,h",
+        "i,j",
+        "k,l",
+        "m,n",
+        "o,p",
+        "q,r",
+        "s,t",
+        "u,v",
+        "w,x",
+        "y,z"
+      ]
+      |> to_stream
 
-    assert result ==  [
-      ok: ~w(a be),
-      ok: ~w(c d),
-      ok: ~w(e f),
-      ok: ~w(g h),
-      ok: ~w(i j),
-      ok: ~w(k l),
-      ok: ~w(m n),
-      ok: ~w(o p),
-      ok: ~w(q r),
-      ok: ~w(s t),
-      ok: ~w(u v),
-      ok: ~w(w x),
-      ok: ~w(y z),
-    ]
+    result = Decoder.decode(stream, num_workers: 3) |> Enum.to_list()
+
+    assert result == [
+             ok: ~w(a be),
+             ok: ~w(c d),
+             ok: ~w(e f),
+             ok: ~w(g h),
+             ok: ~w(i j),
+             ok: ~w(k l),
+             ok: ~w(m n),
+             ok: ~w(o p),
+             ok: ~w(q r),
+             ok: ~w(s t),
+             ok: ~w(u v),
+             ok: ~w(w x),
+             ok: ~w(y z)
+           ]
   end
-
 end

--- a/test/decoding/headers_test.exs
+++ b/test/decoding/headers_test.exs
@@ -6,32 +6,31 @@ defmodule DecodingTests.HeadersTest do
 
   test "parses strings into maps when headers are set to true" do
     stream = ["a,be", "c,d", "e,f"] |> to_stream
-    result = Decoder.decode(stream, headers: true) |> Enum.to_list
+    result = Decoder.decode(stream, headers: true) |> Enum.to_list()
 
-    assert result |> Enum.sort == [
-      ok: %{"a" => "c", "be" => "d"},
-      ok: %{"a" => "e", "be" => "f"}
-    ]
+    assert result |> Enum.sort() == [
+             ok: %{"a" => "c", "be" => "d"},
+             ok: %{"a" => "e", "be" => "f"}
+           ]
   end
 
   test "parses strings and strips cells when headers are given and strip_fields is true" do
     stream = ["h1,h2", "a, be free ", "c,d"] |> to_stream
-    result = Decoder.decode(stream, headers: true, strip_fields: true) |> Enum.to_list
+    result = Decoder.decode(stream, headers: true, strip_fields: true) |> Enum.to_list()
 
     assert result == [
-      ok: %{"h1" => "a", "h2" => "be free"},
-      ok: %{"h1" => "c", "h2" => "d"}
-    ]
+             ok: %{"h1" => "a", "h2" => "be free"},
+             ok: %{"h1" => "c", "h2" => "d"}
+           ]
   end
 
   test "parses strings into maps when headers are given as a list" do
     stream = ["a,be", "c,d"] |> to_stream
-    result = Decoder.decode(stream, headers: [:a, :b]) |> Enum.to_list
+    result = Decoder.decode(stream, headers: [:a, :b]) |> Enum.to_list()
 
     assert result == [
-      ok: %{:a => "a", :b => "be"},
-      ok: %{:a => "c", :b => "d"}
-    ]
+             ok: %{:a => "a", :b => "be"},
+             ok: %{:a => "c", :b => "d"}
+           ]
   end
-
 end

--- a/test/decoding/lexing/baseline_test.exs
+++ b/test/decoding/lexing/baseline_test.exs
@@ -7,35 +7,42 @@ defmodule LexingTests.BaselineTest do
   test "parses strings into a list of token tuples" do
     lexed = Lexer.lex({"a,be\r\n", 11})
 
-    assert lexed == {:ok, [
-        {:content, "a"},
-        {:separator, ","},
-        {:content, "be"},
-        {:delimiter, "\r\n"}
-      ], 11}
+    assert lexed ==
+             {:ok,
+              [
+                {:content, "a"},
+                {:separator, ","},
+                {:content, "be"},
+                {:delimiter, "\r\n"}
+              ], 11}
   end
 
   test "parse escape sequences into a list of token tuples" do
     lexed = Lexer.lex({"\"c,d", 11})
-    assert lexed == {:ok, [
-        {:double_quote, "\""},
-        {:content, "c"},
-        {:separator, ","},
-        {:content, "d"}
-      ], 11}
+
+    assert lexed ==
+             {:ok,
+              [
+                {:double_quote, "\""},
+                {:content, "c"},
+                {:separator, ","},
+                {:content, "d"}
+              ], 11}
   end
 
   test "parses strings into a list of token tuples with quotes" do
     lexed = Lexer.lex({"a,\"be\"\"\r\n", 1})
 
-    assert lexed == {:ok, [
-        {:content, "a"},
-        {:separator, ","},
-        {:double_quote, "\""},
-        {:content, "be"},
-        {:double_quote, "\""},
-        {:double_quote, "\""},
-        {:delimiter, "\r\n"}
-      ], 1}
+    assert lexed ==
+             {:ok,
+              [
+                {:content, "a"},
+                {:separator, ","},
+                {:double_quote, "\""},
+                {:content, "be"},
+                {:double_quote, "\""},
+                {:double_quote, "\""},
+                {:delimiter, "\r\n"}
+              ], 1}
   end
 end

--- a/test/decoding/non_repeatable_stream_test.exs
+++ b/test/decoding/non_repeatable_stream_test.exs
@@ -5,12 +5,13 @@ defmodule DecodingTests.NonRepeatableStreamTest do
   test "decodes from a non-repeatable stream" do
     {:ok, out} =
       "a,b,c\nd,e,f"
-      |> StringIO.open
+      |> StringIO.open()
 
-    result = out
-             |> IO.binstream(:line)
-             |> Decoder.decode
-             |> Enum.to_list
+    result =
+      out
+      |> IO.binstream(:line)
+      |> Decoder.decode()
+      |> Enum.to_list()
 
     assert result == [ok: ~w(a b c), ok: ~w(d e f)]
   end
@@ -18,16 +19,17 @@ defmodule DecodingTests.NonRepeatableStreamTest do
   test "decodes with headers from a non-repeatable stream" do
     {:ok, out} =
       "a,b,c\nd,e,f\ng,h,i"
-      |> StringIO.open
+      |> StringIO.open()
 
-    result = out
-             |> IO.binstream(:line)
-             |> Decoder.decode(headers: true)
-             |> Enum.to_list
+    result =
+      out
+      |> IO.binstream(:line)
+      |> Decoder.decode(headers: true)
+      |> Enum.to_list()
 
     assert result == [
-      ok: %{"a" => "d", "b" => "e", "c" => "f"},
-      ok: %{"a" => "g", "b" => "h", "c" => "i"}
-    ]
+             ok: %{"a" => "d", "b" => "e", "c" => "f"},
+             ok: %{"a" => "g", "b" => "h", "c" => "i"}
+           ]
   end
 end

--- a/test/decoding/parsing/baseline_test.exs
+++ b/test/decoding/parsing/baseline_test.exs
@@ -6,126 +6,150 @@ defmodule DecodingTests.ParsingTests.BaselineTest do
   doctest Parser
 
   test "turns a sequence of tokens into a csv matrix" do
-    parsed = Enum.map [
-      {[
-          {:content, "a"},
-          {:separator, ","},
-          {:content, "b"},
-          {:delimiter, "\r\n"},
-        ], 1}, {[
-          {:content, "c"},
-          {:separator, ","},
-          {:content, "d"},
-        ], 2}
-    ], &Parser.parse/1
+    parsed =
+      Enum.map(
+        [
+          {[
+             {:content, "a"},
+             {:separator, ","},
+             {:content, "b"},
+             {:delimiter, "\r\n"}
+           ], 1},
+          {[
+             {:content, "c"},
+             {:separator, ","},
+             {:content, "d"}
+           ], 2}
+        ],
+        &Parser.parse/1
+      )
 
     assert parsed == [
-      {:ok, ~w(a b), 1},
-      {:ok, ~w(c d), 2}
-    ]
+             {:ok, ~w(a b), 1},
+             {:ok, ~w(c d), 2}
+           ]
   end
 
   test "turns a sequence of tokens into a csv matrix and strips cells" do
-    parsed = Enum.map [
-      {[
-          {:content, " "},
-          {:content, " "},
-          {:content, "a"},
-          {:content, " "},
-          {:separator, ","},
-          {:content, "b"},
-          {:delimiter, "\r\n"},
-        ], 1}, {[
-          {:content, " "},
-          {:content, "c"},
-          {:separator, ","},
-          {:content, " "},
-          {:content, "d"},
-          {:content, " "},
-        ], 2}
-    ], &Parser.parse(&1, strip_fields: true)
+    parsed =
+      Enum.map(
+        [
+          {[
+             {:content, " "},
+             {:content, " "},
+             {:content, "a"},
+             {:content, " "},
+             {:separator, ","},
+             {:content, "b"},
+             {:delimiter, "\r\n"}
+           ], 1},
+          {[
+             {:content, " "},
+             {:content, "c"},
+             {:separator, ","},
+             {:content, " "},
+             {:content, "d"},
+             {:content, " "}
+           ], 2}
+        ],
+        &Parser.parse(&1, strip_fields: true)
+      )
 
     assert parsed == [
-      {:ok, ~w(a b), 1},
-      {:ok, ~w(c d), 2}
-    ]
+             {:ok, ~w(a b), 1},
+             {:ok, ~w(c d), 2}
+           ]
   end
 
   test "turns a sequence of tokens with escape sequences into a csv matrix" do
-    parsed = Enum.map [
-      {[
-          {:content, "a"},
-          {:separator, ","},
-          {:double_quote, "\""},
-          {:content, "b"},
-          {:delimiter, "\r\n"},
-          {:content, "c"},
-          {:separator, ","},
-          {:double_quote, "\""},
-        ], 1}, {[
-          {:delimiter, "\r\n"},
-          {:content, "c"},
-          {:separator, ","},
-          {:content, "d"},
-        ], 2}
-    ], &Parser.parse/1
+    parsed =
+      Enum.map(
+        [
+          {[
+             {:content, "a"},
+             {:separator, ","},
+             {:double_quote, "\""},
+             {:content, "b"},
+             {:delimiter, "\r\n"},
+             {:content, "c"},
+             {:separator, ","},
+             {:double_quote, "\""}
+           ], 1},
+          {[
+             {:delimiter, "\r\n"},
+             {:content, "c"},
+             {:separator, ","},
+             {:content, "d"}
+           ], 2}
+        ],
+        &Parser.parse/1
+      )
 
     assert parsed == [
-      {:ok, ["a", "b\r\nc,"], 1},
-      {:ok, ["c", "d"], 2}
-    ]
+             {:ok, ["a", "b\r\nc,"], 1},
+             {:ok, ["c", "d"], 2}
+           ]
   end
 
   test "manages escaped double quotes inside double quoted fields according to RFC 4180" do
-    parsed = Enum.map [
-      {[
-          {:content, "a"},
-          {:separator, ","},
-          {:double_quote, "\""},
-          {:content, "b"},
-          {:double_quote, "\""},
-          {:double_quote, "\""},
-          {:content, "c"},
-          {:separator, ","},
-          {:double_quote, "\""},
-        ], 1}, {[
-          {:delimiter, "\r\n"},
-          {:content, "c"},
-          {:separator, ","},
-          {:content, "d"},
-        ], 2}
-    ], &Parser.parse/1
+    parsed =
+      Enum.map(
+        [
+          {[
+             {:content, "a"},
+             {:separator, ","},
+             {:double_quote, "\""},
+             {:content, "b"},
+             {:double_quote, "\""},
+             {:double_quote, "\""},
+             {:content, "c"},
+             {:separator, ","},
+             {:double_quote, "\""}
+           ], 1},
+          {[
+             {:delimiter, "\r\n"},
+             {:content, "c"},
+             {:separator, ","},
+             {:content, "d"}
+           ], 2}
+        ],
+        &Parser.parse/1
+      )
 
     assert parsed == [
-      {:ok, ["a", "b\"c,"], 1},
-      {:ok, ["c", "d"], 2}
-    ]
+             {:ok, ["a", "b\"c,"], 1},
+             {:ok, ["c", "d"], 2}
+           ]
   end
 
   test "manages escaped double quotes at the beginning of double quoted fields according to RFC 4180" do
-    parsed = Enum.map [
-      {[
-          {:content, "a"},
-          {:separator, ","},
-          {:double_quote, "\""},
-          {:double_quote, "\""},
-          {:double_quote, "\""},
-          {:content, "b"},
-          {:content, "c"},
-          {:separator, ","},
-          {:double_quote, "\""},
-        ], 1}, {[
-          {:delimiter, "\r\n"},
-          {:content, "c"},
-          {:separator, ","},
-          {:content, "d"},
-        ], 2}
-    ], &Parser.parse/1
+    parsed =
+      Enum.map(
+        [
+          {[
+             {:content, "a"},
+             {:separator, ","},
+             {:double_quote, "\""},
+             {:double_quote, "\""},
+             {:double_quote, "\""},
+             {:content, "b"},
+             {:content, "c"},
+             {:separator, ","},
+             {:double_quote, "\""}
+           ], 1},
+          {[
+             {:delimiter, "\r\n"},
+             {:content, "c"},
+             {:separator, ","},
+             {:content, "d"}
+           ], 2}
+        ],
+        &Parser.parse/1
+      )
 
     assert parsed == [
-      {:ok, ["a", "\"bc,"], 1},
-      {:ok, ["c", "d"], 2}
-    ]
+             {:ok, ["a", "\"bc,"], 1},
+             {:ok, ["c", "d"], 2}
+           ]
   end
-
 end

--- a/test/decoding/parsing/exceptions_test.exs
+++ b/test/decoding/parsing/exceptions_test.exs
@@ -5,77 +5,92 @@ defmodule DecodingTests.ParsingTests.ExceptionsTest do
   alias CSV.EscapeSequenceError
 
   test "raises a escape sequence error when given an invalid sequence of tokens" do
-    parsed = Enum.map [
-      {[
-          {:double_quote, "\""},
-          {:delimiter, "\r\n"},
-          {:content, "c"},
-          {:separator, ","},
-          {:content, "d"},
-        ], 1}, {[
-          {:content, "a"},
-          {:separator, ","},
-          {:double_quote, "\""},
-          {:content, "b"},
-          {:double_quote, "\""},
-          {:double_quote, "\""},
-          {:content, "c"},
-          {:separator, ","},
-          {:double_quote, "\""},
-        ], 2}
-    ], &Parser.parse/1
+    parsed =
+      Enum.map(
+        [
+          {[
+             {:double_quote, "\""},
+             {:delimiter, "\r\n"},
+             {:content, "c"},
+             {:separator, ","},
+             {:content, "d"}
+           ], 1},
+          {[
+             {:content, "a"},
+             {:separator, ","},
+             {:double_quote, "\""},
+             {:content, "b"},
+             {:double_quote, "\""},
+             {:double_quote, "\""},
+             {:content, "c"},
+             {:separator, ","},
+             {:double_quote, "\""}
+           ], 2}
+        ],
+        &Parser.parse/1
+      )
 
     assert parsed == [
-      {:error, EscapeSequenceError, "\r\nc,d", 1},
-      {:ok, ["a", "b\"c,"], 2},
-    ]
+             {:error, EscapeSequenceError, "\r\nc,d", 1},
+             {:ok, ["a", "b\"c,"], 2}
+           ]
   end
 
   test "raises an escape sequence error when halted in an escape sequence" do
-    parsed = Enum.map [
-      {[
-          {:content, "a"},
-          {:separator, ","},
-          {:double_quote, "\""},
-          {:content, "b"},
-          {:double_quote, "\""},
-          {:double_quote, "\""},
-          {:content, "c"},
-          {:separator, ","},
-          {:double_quote, "\""},
-        ], 1}, {[
-          {:double_quote, "\""},
-          {:delimiter, "\r\n"},
-          {:content, "c"},
-          {:separator, ","},
-          {:content, "d"},
-        ], 2}
-    ], &Parser.parse/1
+    parsed =
+      Enum.map(
+        [
+          {[
+             {:content, "a"},
+             {:separator, ","},
+             {:double_quote, "\""},
+             {:content, "b"},
+             {:double_quote, "\""},
+             {:double_quote, "\""},
+             {:content, "c"},
+             {:separator, ","},
+             {:double_quote, "\""}
+           ], 1},
+          {[
+             {:double_quote, "\""},
+             {:delimiter, "\r\n"},
+             {:content, "c"},
+             {:separator, ","},
+             {:content, "d"}
+           ], 2}
+        ],
+        &Parser.parse/1
+      )
 
     assert parsed == [
-      {:ok, ["a", "b\"c,"], 1},
-      {:error, EscapeSequenceError, "\r\nc,d", 2},
-    ]
+             {:ok, ["a", "b\"c,"], 1},
+             {:error, EscapeSequenceError, "\r\nc,d", 2}
+           ]
   end
 
   test "the parser propagates errors" do
-    parsed = Enum.map [
-      {[
-          {:content, "a"},
-          {:separator, ","},
-          {:double_quote, "\""},
-          {:content, "b"},
-          {:double_quote, "\""},
-          {:double_quote, "\""},
-          {:content, "c"},
-          {:separator, ","},
-          {:double_quote, "\""},
-        ], 1}, {:error, RuntimeError, "MESSAGE", 2}
-    ], &Parser.parse/1
+    parsed =
+      Enum.map(
+        [
+          {[
+             {:content, "a"},
+             {:separator, ","},
+             {:double_quote, "\""},
+             {:content, "b"},
+             {:double_quote, "\""},
+             {:double_quote, "\""},
+             {:content, "c"},
+             {:separator, ","},
+             {:double_quote, "\""}
+           ], 1},
+          {:error, RuntimeError, "MESSAGE", 2}
+        ],
+        &Parser.parse/1
+      )
 
     assert parsed == [
-      {:ok, ["a", "b\"c,"], 1},
-      {:error, RuntimeError, "MESSAGE", 2},
-    ]
+             {:ok, ["a", "b\"c,"], 1},
+             {:error, RuntimeError, "MESSAGE", 2}
+           ]
   end
 end

--- a/test/decoding/preprocessing/lines_exceptions_test.exs
+++ b/test/decoding/preprocessing/lines_exceptions_test.exs
@@ -5,36 +5,43 @@ defmodule DecodingTests.PreprocessingTests.LinesExceptionsTest do
   alias CSV.Decoding.Preprocessing.Lines
 
   test "passes on open escape sequences at the end of the stream" do
-    stream = ["a,\"be\"\"", "c,d", "e,f\",\"super,cool\"", "g,h,i", "i,j,\"k", "k,l,m"] |> to_stream
-    processed = stream |> Lines.process |> Enum.to_list
+    stream =
+      ["a,\"be\"\"", "c,d", "e,f\",\"super,cool\"", "g,h,i", "i,j,\"k", "k,l,m"] |> to_stream
+
+    processed = stream |> Lines.process() |> Enum.to_list()
 
     assert processed == [
-      "a,\"be\"\"\r\nc,d\r\ne,f\",\"super,cool\"",
-      "g,h,i", "i,j,\"k", "k,l,m"
-    ]
+             "a,\"be\"\"\r\nc,d\r\ne,f\",\"super,cool\"",
+             "g,h,i",
+             "i,j,\"k",
+             "k,l,m"
+           ]
   end
 
   test "passes on if the multiline escape exceeds the maximum number of lines allowed to be aggregated" do
     stream = ["a,\"be\"\"", "c,d", "e,f", "g,h", "i,k", "\",b", "k,l,m"] |> to_stream
-    processed = stream |> Lines.process(escape_max_lines: 2) |> Enum.to_list
+    processed = stream |> Lines.process(escape_max_lines: 2) |> Enum.to_list()
 
     assert processed == ["a,\"be\"\"", "c,d", "e,f", "g,h", "i,k", "\",b", "k,l,m"]
   end
 
   test "passes on open escape sequences with escaped quotes" do
     stream = ["a,\"\"\"be\"\"", "\"\"c,d"] |> to_stream
-    processed = stream |> Lines.process |> Enum.to_list
+    processed = stream |> Lines.process() |> Enum.to_list()
 
     assert processed == ["a,\"\"\"be\"\"", "\"\"c,d"]
   end
 
   test "passes on open escape sequences but processes subsequent escape sequences" do
     stream = ["a,\"be\"\"", "c,d", "e,f", "g,\"h", "i,k", "\",b", "k,l,m"] |> to_stream
-    processed = stream |> Lines.process(escape_max_lines: 3) |> Enum.to_list
+    processed = stream |> Lines.process(escape_max_lines: 3) |> Enum.to_list()
 
     assert processed == [
-      "a,\"be\"\"", "c,d", "e,f",
-      "g,\"h\r\ni,k\r\n\",b", "k,l,m"
-    ]
+             "a,\"be\"\"",
+             "c,d",
+             "e,f",
+             "g,\"h\r\ni,k\r\n\",b",
+             "k,l,m"
+           ]
   end
 end

--- a/test/decoding/preprocessing/lines_test.exs
+++ b/test/decoding/preprocessing/lines_test.exs
@@ -6,203 +6,223 @@ defmodule DecodingTests.PreprocessingTests.LinesTest do
 
   test "does not aggregate normal lines" do
     stream = ~w(g,h i,j k,l) |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    aggregated = stream |> Lines.process() |> Enum.to_list()
     assert aggregated == ~w(g,h i,j k,l)
   end
 
   test "does not aggregate escaped normal lines" do
     stream = ~w("g",h "i",j k,"l") |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    aggregated = stream |> Lines.process() |> Enum.to_list()
     assert aggregated == ~w("g",h "i",j k,"l")
   end
 
   test "does not aggregate escaped normal lines with escaped quotes" do
     stream = ~w("g""","""h" "i",j k,"""l") |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    aggregated = stream |> Lines.process() |> Enum.to_list()
     assert aggregated == ~w("g""","""h" "i",j k,"""l")
   end
 
   test "does not aggregate empty lines" do
     stream = ~w(g, , ,l) |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    aggregated = stream |> Lines.process() |> Enum.to_list()
     assert aggregated == ~w(g, , ,l)
   end
 
   test "does not aggregate partially empty lines with escape sequences" do
     stream = ~w(g, ,"""" ,l "","") |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    aggregated = stream |> Lines.process() |> Enum.to_list()
     assert aggregated == ~w(g, ,"""" ,l "","")
   end
 
   test "does not aggregate terminated escape sequences" do
     stream = ["a,\"be\"\"\"", "c,\"\"\"d\"\"\"\"\"", "\"e,f\"\"\",g"] |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    aggregated = stream |> Lines.process() |> Enum.to_list()
+
     assert aggregated == [
-      "a,\"be\"\"\"",
-      "c,\"\"\"d\"\"\"\"\"",
-      "\"e,f\"\"\",g"
-    ]
+             "a,\"be\"\"\"",
+             "c,\"\"\"d\"\"\"\"\"",
+             "\"e,f\"\"\",g"
+           ]
   end
 
   test "aggregates lines with terminated escape sequences and separators in escapes" do
     stream = ["a,\"be\"\"", "c,\"\"d", "e,f\"", "\"g\",\"h\"\",\"", "\"i\",\"j\""] |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
-    assert aggregated == [
-      "a,\"be\"\"\r\nc,\"\"d\r\ne,f\"",
-      "\"g\",\"h\"\",\"",
-      "\"i\",\"j\""
-    ]
-  end
+    aggregated = stream |> Lines.process() |> Enum.to_list()
 
+    assert aggregated == [
+             "a,\"be\"\"\r\nc,\"\"d\r\ne,f\"",
+             "\"g\",\"h\"\",\"",
+             "\"i\",\"j\""
+           ]
+  end
 
   test "aggregates unterminated escape sequences over lines" do
     stream = ["a,\"be", "c,d", "e,f\"", "g,h"] |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    aggregated = stream |> Lines.process() |> Enum.to_list()
+
     assert aggregated == [
-      "a,\"be\r\nc,d\r\ne,f\"",
-      "g,h"
-    ]
+             "a,\"be\r\nc,d\r\ne,f\"",
+             "g,h"
+           ]
   end
 
   test "aggregates unterminated escape sequences only containing line breaks over lines" do
     stream = ["a,\"", "\"", "c,d"] |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    aggregated = stream |> Lines.process() |> Enum.to_list()
+
     assert aggregated == [
-      "a,\"\r\n\"",
-      "c,d"
-    ]
+             "a,\"\r\n\"",
+             "c,d"
+           ]
   end
 
   test "aggregates unterminated escape sequences over rows with different separators" do
     stream = ["a\t\"be", "c\td", "e\tf\"", "g\th"] |> to_stream
-    aggregated = stream |> Lines.process(separator: ?\t) |> Enum.to_list
+    aggregated = stream |> Lines.process(separator: ?\t) |> Enum.to_list()
+
     assert aggregated == [
-      "a\t\"be\r\nc\td\r\ne\tf\"",
-      "g\th",
-    ]
+             "a\t\"be\r\nc\td\r\ne\tf\"",
+             "g\th"
+           ]
   end
 
   test "aggregates unterminated escape sequences over rows with multiple quotes" do
     stream = ["a,\"\"\"be", "c,d", "e,f\"", "g,h"] |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    aggregated = stream |> Lines.process() |> Enum.to_list()
+
     assert aggregated == [
-      "a,\"\"\"be\r\nc,d\r\ne,f\"",
-      "g,h"
-    ]
+             "a,\"\"\"be\r\nc,d\r\ne,f\"",
+             "g,h"
+           ]
   end
 
   test "aggregates unterminated escape sequences where the sequence begins at the start of the row" do
     stream = ["\"\"\"be", "c,d", "e,f\",g", "g,h"] |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    aggregated = stream |> Lines.process() |> Enum.to_list()
+
     assert aggregated == [
-      "\"\"\"be\r\nc,d\r\ne,f\",g",
-      "g,h"
-    ]
+             "\"\"\"be\r\nc,d\r\ne,f\",g",
+             "g,h"
+           ]
   end
 
   test "aggregates lines with escaped quotes in escape sequences" do
     stream = ["a,\"be\"\"", "c,\"\"d", "e,f\"", "g,\"h\"\"\"\"", "i,j\"", "k,l"] |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    aggregated = stream |> Lines.process() |> Enum.to_list()
+
     assert aggregated == [
-      "a,\"be\"\"\r\nc,\"\"d\r\ne,f\"",
-      "g,\"h\"\"\"\"\r\ni,j\"",
-      "k,l"
-    ]
+             "a,\"be\"\"\r\nc,\"\"d\r\ne,f\"",
+             "g,\"h\"\"\"\"\r\ni,j\"",
+             "k,l"
+           ]
   end
 
   test "aggregates lines with escaped quotes and separators in escapes" do
     stream = ["a,\"be\"\"", "c,\"\"d", "e,f\"", "g,\"h\"\",\"\"", "i,j\"", "k,l"] |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    aggregated = stream |> Lines.process() |> Enum.to_list()
+
     assert aggregated == [
-      "a,\"be\"\"\r\nc,\"\"d\r\ne,f\"",
-      "g,\"h\"\",\"\"\r\ni,j\"",
-      "k,l"
-    ]
+             "a,\"be\"\"\r\nc,\"\"d\r\ne,f\"",
+             "g,\"h\"\",\"\"\r\ni,j\"",
+             "k,l"
+           ]
   end
 
   test "aggregates partially empty lines with open escape sequences" do
     stream = [",,\"be", "c,d", "e,f\"", "g,,\"h\"\"\"\"", "i,,j\"", "k,l,"] |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
-    assert aggregated == [
-      ",,\"be\r\nc,d\r\ne,f\"",
-      "g,,\"h\"\"\"\"\r\ni,,j\"",
-      "k,l,"
-    ]
-  end
+    aggregated = stream |> Lines.process() |> Enum.to_list()
 
+    assert aggregated == [
+             ",,\"be\r\nc,d\r\ne,f\"",
+             "g,,\"h\"\"\"\"\r\ni,,j\"",
+             "k,l,"
+           ]
+  end
 
   test "aggregates lines with escape sequences ending in the next line" do
     stream = ["a,\"be\"\"", "c,d", "e,f\",\"super,cool\"", "g,h,i"] |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    aggregated = stream |> Lines.process() |> Enum.to_list()
+
     assert aggregated == [
-      "a,\"be\"\"\r\nc,d\r\ne,f\",\"super,cool\"",
-      "g,h,i"
-    ]
+             "a,\"be\"\"\r\nc,d\r\ne,f\",\"super,cool\"",
+             "g,h,i"
+           ]
   end
 
   test "aggregates lines with escape sequences that are ending with a separator" do
     stream = ["a,\"be\"\"", "c,d", "e,f,\",\"super,cool\"", "g,h,i"] |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    aggregated = stream |> Lines.process() |> Enum.to_list()
+
     assert aggregated == [
-      "a,\"be\"\"\r\nc,d\r\ne,f,\",\"super,cool\"",
-      "g,h,i"
-    ]
+             "a,\"be\"\"\r\nc,d\r\ne,f,\",\"super,cool\"",
+             "g,h,i"
+           ]
   end
 
   test "aggregates lines with escape sequences that are starting with a linebreak" do
     stream = ["a,be,\"", "c,d\"", "g,h,i"] |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    aggregated = stream |> Lines.process() |> Enum.to_list()
+
     assert aggregated == [
-      "a,be,\"\r\nc,d\"",
-      "g,h,i"
-    ]
+             "a,be,\"\r\nc,d\"",
+             "g,h,i"
+           ]
   end
 
   test "aggregates lines with escape sequences that are ending with a linebreak" do
     stream = ["a,be,\"", "c,\"\"d", "\"\"\"", "g,h,i"] |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    aggregated = stream |> Lines.process() |> Enum.to_list()
+
     assert aggregated == [
-      "a,be,\"\r\nc,\"\"d\r\n\"\"\"",
-      "g,h,i"
-    ]
+             "a,be,\"\r\nc,\"\"d\r\n\"\"\"",
+             "g,h,i"
+           ]
   end
 
   test "aggregates lines with escaped quotes after a linebreak" do
     stream = ["a,be,\"", "c", "\"\"d", "e", "\"\"\",f", "g,h,i,k"] |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    aggregated = stream |> Lines.process() |> Enum.to_list()
+
     assert aggregated == [
-      "a,be,\"\r\nc\r\n\"\"d\r\ne\r\n\"\"\",f",
-      "g,h,i,k"
-    ]
+             "a,be,\"\r\nc\r\n\"\"d\r\ne\r\n\"\"\",f",
+             "g,h,i,k"
+           ]
   end
 
   test "aggregates lines with escape sequences that are containing a linebreak" do
     stream = ["a,be,\"", "c,\"\"d", "\"\"\"", "g,h,i"] |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    aggregated = stream |> Lines.process() |> Enum.to_list()
+
     assert aggregated == [
-      "a,be,\"\r\nc,\"\"d\r\n\"\"\"",
-      "g,h,i"
-    ]
+             "a,be,\"\r\nc,\"\"d\r\n\"\"\"",
+             "g,h,i"
+           ]
   end
 
   test "aggregates lines with multiple escape sequences in the same stream" do
-    stream = ["a,\"be\"\"", "c,d", "e,f\",\"super,cool\"", "g,\"h,i", "i,j\",k", "k,l,m"] |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
+    stream =
+      ["a,\"be\"\"", "c,d", "e,f\",\"super,cool\"", "g,\"h,i", "i,j\",k", "k,l,m"] |> to_stream
+
+    aggregated = stream |> Lines.process() |> Enum.to_list()
+
     assert aggregated == [
-      "a,\"be\"\"\r\nc,d\r\ne,f\",\"super,cool\"",
-      "g,\"h,i\r\ni,j\",k",
-      "k,l,m"
-    ]
+             "a,\"be\"\"\r\nc,d\r\ne,f\",\"super,cool\"",
+             "g,\"h,i\r\ni,j\",k",
+             "k,l,m"
+           ]
   end
 
   test "aggregates lines with multiple escape sequences in the same row" do
-    stream = ["a,\"be\"\"", "c,d", "e,f\",\",\",\"super,cool", "g,\"", "h,\"i,l", "\",\"j\",k", "k,l,m"] |> to_stream
-    aggregated = stream |> Lines.process |> Enum.to_list
-    assert aggregated == [
-      "a,\"be\"\"\r\nc,d\r\ne,f\",\",\",\"super,cool\r\ng,\"",
-      "h,\"i,l\r\n\",\"j\",k",
-      "k,l,m"
-    ]
-  end
+    stream =
+      ["a,\"be\"\"", "c,d", "e,f\",\",\",\"super,cool", "g,\"", "h,\"i,l", "\",\"j\",k", "k,l,m"]
+      |> to_stream
 
+    aggregated = stream |> Lines.process() |> Enum.to_list()
+
+    assert aggregated == [
+             "a,\"be\"\"\r\nc,d\r\ne,f\",\",\",\"super,cool\r\ng,\"",
+             "h,\"i,l\r\n\",\"j\",k",
+             "k,l,m"
+           ]
+  end
 end

--- a/test/decoding/preprocessing/none_test.exs
+++ b/test/decoding/preprocessing/none_test.exs
@@ -6,12 +6,12 @@ defmodule DecodingTests.PreprocessingTests.NoneTest do
 
   test "does pass the input to the output directly" do
     stream = ~w(g,h i,j k,l) |> to_stream
-    aggregated = stream |> None.process |> Enum.to_list
-    assert aggregated == [
-      "g,h",
-      "i,j",
-      "k,l"
-    ]
-  end
+    aggregated = stream |> None.process() |> Enum.to_list()
 
+    assert aggregated == [
+             "g,h",
+             "i,j",
+             "k,l"
+           ]
+  end
 end

--- a/test/decoding/separators_test.exs
+++ b/test/decoding/separators_test.exs
@@ -6,16 +6,15 @@ defmodule DecodingTests.SeparatorsTest do
 
   test "parses strings separated by custom separators into a list of fields" do
     stream = ["a;be", "c;d"] |> to_stream
-    result = Decoder.decode(stream, separator: ?;) |> Enum.to_list
+    result = Decoder.decode(stream, separator: ?;) |> Enum.to_list()
 
     assert result == [ok: ~w(a be), ok: ~w(c d)]
   end
 
   test "parses strings separated by custom tab separators into a list of fields" do
     stream = ["a\tbe", "c\td"] |> to_stream
-    result = Decoder.decode(stream, separator: ?\t) |> Enum.to_list
+    result = Decoder.decode(stream, separator: ?\t) |> Enum.to_list()
 
     assert result == [ok: ~w(a be), ok: ~w(c d)]
   end
-
 end

--- a/test/decoding/strip_fields_test.exs
+++ b/test/decoding/strip_fields_test.exs
@@ -6,9 +6,8 @@ defmodule DecodingTests.StripFieldsTest do
 
   test "parses strings and strips fields when given the option" do
     stream = ["  a , be", "c,    d\t"] |> to_stream
-    result = Decoder.decode(stream, strip_fields: true) |> Enum.to_list
+    result = Decoder.decode(stream, strip_fields: true) |> Enum.to_list()
 
     assert result == [ok: ~w(a be), ok: ~w(c d)]
   end
-
 end

--- a/test/encoding/baseline_test.exs
+++ b/test/encoding/baseline_test.exs
@@ -5,12 +5,12 @@ defmodule EncodingTests.BaselineTest do
   doctest Encoder
 
   test "encodes streams to csv strings" do
-    result = Encoder.encode([~w(a b), ~w(c d)]) |> Enum.to_list
+    result = Encoder.encode([~w(a b), ~w(c d)]) |> Enum.to_list()
     assert result == ["a,b\r\n", "c,d\r\n"]
   end
 
   test "allows custom separators and delimiters" do
-    result = Encoder.encode([~w(a b), ~w(c d)], separator: ?;, delimiter: "\n") |> Enum.to_list
+    result = Encoder.encode([~w(a b), ~w(c d)], separator: ?;, delimiter: "\n") |> Enum.to_list()
     assert result == ["a;b\n", "c;d\n"]
   end
 end

--- a/test/encoding/escaped_fields_test.exs
+++ b/test/encoding/escaped_fields_test.exs
@@ -3,18 +3,20 @@ defmodule EncodingTests.EscapedFieldsTest do
   alias CSV.Encoding.Encoder
 
   test "encodes streams to csv strings and escapes them" do
-    result = Encoder.encode([["a,", "b\re"], ["c,f\"", "dg"]]) |> Enum.to_list
+    result = Encoder.encode([["a,", "b\re"], ["c,f\"", "dg"]]) |> Enum.to_list()
     assert result == ["\"a,\",\"b\\re\"\r\n", "\"c,f\"\"\",dg\r\n"]
   end
 
   test "encodes streams of various content to csv strings and escapes them" do
-    result = Encoder.encode([[:atom, 1], [["a", "b"], "dg"]]) |> Enum.to_list
+    result = Encoder.encode([[:atom, 1], [["a", "b"], "dg"]]) |> Enum.to_list()
     assert result == ["atom,1\r\n", "ab,dg\r\n"]
   end
 
   test "allows custom separators and delimiters and escapes them" do
-    result = Encoder.encode([["a\t", "b\re"], ["c\tf\"", "dg"]], separator: ?\t, delimiter: "\n") |> Enum.to_list
+    result =
+      Encoder.encode([["a\t", "b\re"], ["c\tf\"", "dg"]], separator: ?\t, delimiter: "\n")
+      |> Enum.to_list()
+
     assert result == ["\"a\\t\"\t\"b\\re\"\n", "\"c\\tf\"\"\"\tdg\n"]
   end
-
 end

--- a/test/encoding/headers_test.exs
+++ b/test/encoding/headers_test.exs
@@ -3,12 +3,12 @@ defmodule EncodingTests.HeadersTest do
   alias CSV.Encoding.Encoder
 
   test "use keys from first row as headers when headers: true" do
-    result = Encoder.encode([%{"a" => 1, "b" => 2}], headers: true) |> Enum.to_list
+    result = Encoder.encode([%{"a" => 1, "b" => 2}], headers: true) |> Enum.to_list()
     assert result == ["a,b\r\n", "1,2\r\n"]
   end
 
   test "inserts specified headers as first row and uses them to order columns" do
-    result = Encoder.encode([%{"c" => 1, "b" => 2}], headers: ["c", "b", "a"]) |> Enum.to_list
+    result = Encoder.encode([%{"c" => 1, "b" => 2}], headers: ["c", "b", "a"]) |> Enum.to_list()
     assert result == ["c,b,a\r\n", "1,2,\r\n"]
   end
 end

--- a/test/encoding/protocol_test.exs
+++ b/test/encoding/protocol_test.exs
@@ -18,7 +18,6 @@ defmodule EncodingTests.ProtocolTest do
   end
 
   test "it falls back to to_string for lists" do
-    assert CSV.Encode.encode([1,2,3]) == <<1, 2, 3>>
+    assert CSV.Encode.encode([1, 2, 3]) == <<1, 2, 3>>
   end
-
 end

--- a/test/escaped_fields_exceptions_test.exs
+++ b/test/escaped_fields_exceptions_test.exs
@@ -4,31 +4,32 @@ defmodule DecodingTests.EscapedFieldsExceptionsTest do
 
   test "parses strings unless they contain unfinished escape sequences" do
     stream = ["a,be", "\"c,d", "u,z"] |> to_stream
-    result = CSV.decode(stream, headers: [:a, :b]) |> Enum.to_list
+    result = CSV.decode(stream, headers: [:a, :b]) |> Enum.to_list()
 
     assert result == [
-      ok: %{a: "a", b: "be"},
-      error: "Escape sequence started on line 2 near \"c,d\" did not terminate.\n\n" <>
-        "Escape sequences are allowed to span up to 1000 lines. " <>
-          "This threshold avoids collecting the whole file into memory " <>
-            "when an escape sequence does not terminate. " <>
-              "You can change it using the escape_max_lines option: https://hexdocs.pm/csv/CSV.html#decode/2",
-      ok: %{a: "u", b: "z"}
-    ]
+             ok: %{a: "a", b: "be"},
+             error:
+               "Escape sequence started on line 2 near \"c,d\" did not terminate.\n\n" <>
+                 "Escape sequences are allowed to span up to 1000 lines. " <>
+                 "This threshold avoids collecting the whole file into memory " <>
+                 "when an escape sequence does not terminate. " <>
+                 "You can change it using the escape_max_lines option: https://hexdocs.pm/csv/CSV.html#decode/2",
+             ok: %{a: "u", b: "z"}
+           ]
   end
 
   test "raises errors for unfinished escape sequences spanning multiple lines" do
     stream = [",ci,\"\"\"", ",c,d"] |> to_stream
-    result = stream |> CSV.decode |> Enum.to_list
+    result = stream |> CSV.decode() |> Enum.to_list()
 
     assert result == [
-      error: "Escape sequence started on line 1 near \"\"\" did not terminate.\n\n"<>
-        "Escape sequences are allowed to span up to 1000 lines. " <>
-          "This threshold avoids collecting the whole file into memory " <>
-            "when an escape sequence does not terminate. " <>
-              "You can change it using the escape_max_lines option: https://hexdocs.pm/csv/CSV.html#decode/2",
-      ok: ["", "c", "d"]
-    ]
+             error:
+               "Escape sequence started on line 1 near \"\"\" did not terminate.\n\n" <>
+                 "Escape sequences are allowed to span up to 1000 lines. " <>
+                 "This threshold avoids collecting the whole file into memory " <>
+                 "when an escape sequence does not terminate. " <>
+                 "You can change it using the escape_max_lines option: https://hexdocs.pm/csv/CSV.html#decode/2",
+             ok: ["", "c", "d"]
+           ]
   end
-
 end

--- a/test/escaped_fields_test.exs
+++ b/test/escaped_fields_test.exs
@@ -10,85 +10,85 @@ defmodule EscapedFieldsTest do
   end
 
   test "collects rows with fields and escape sequences spanning multiple lines" do
-    stream = [
-      # line 1
-      ",,\"",
-      "field three of line one",
-      "contains \"\"quoted\"\" text, ",
-      "multiple \"\"linebreaks\"\"",
-      "and ends on a new line.\"",
-      # line 2
-      "line two has,\"a simple, quoted second field",
-      "with one newline\",and a standard third field",
-      # line 3
-      "\"line three begins with an escaped field,",
-      " continues with\",\"an escaped field,",
-      "and ends\",\"with",
-      "an escaped field\"",
-      # line 4
-      "\"field two in",
-      "line four\",\"",
-      "begins and ends with a newline",
-      "\",\", and field three",
-      "\"\"\"\"",
-      "is full of newlines and quotes\r\n\"",
-      # line 5
-      "\"line five has an empty line in field two\",\"",
-      "",
-      "\",\"\"\"and a doubly quoted third field",
-      "\"\"\"",
-      # line 6 only contains quotes and new lines
-      "\"\"\"\"\"\",\"\"\"",
-      "\"\"\"\"",
-      "\",\"\"\"\"",
-      # line 7
-      "line seven has an intermittent,\"quote",
-      "right after",
-      "\"\"a new line",
-      "and",
-      "ends with a standard, \"\"\",unquoted third field"
-    ] |> to_stream
+    stream =
+      [
+        # line 1
+        ",,\"",
+        "field three of line one",
+        "contains \"\"quoted\"\" text, ",
+        "multiple \"\"linebreaks\"\"",
+        "and ends on a new line.\"",
+        # line 2
+        "line two has,\"a simple, quoted second field",
+        "with one newline\",and a standard third field",
+        # line 3
+        "\"line three begins with an escaped field,",
+        " continues with\",\"an escaped field,",
+        "and ends\",\"with",
+        "an escaped field\"",
+        # line 4
+        "\"field two in",
+        "line four\",\"",
+        "begins and ends with a newline",
+        "\",\", and field three",
+        "\"\"\"\"",
+        "is full of newlines and quotes\r\n\"",
+        # line 5
+        "\"line five has an empty line in field two\",\"",
+        "",
+        "\",\"\"\"and a doubly quoted third field",
+        "\"\"\"",
+        # line 6 only contains quotes and new lines
+        "\"\"\"\"\"\",\"\"\"",
+        "\"\"\"\"",
+        "\",\"\"\"\"",
+        # line 7
+        "line seven has an intermittent,\"quote",
+        "right after",
+        "\"\"a new line",
+        "and",
+        "ends with a standard, \"\"\",unquoted third field"
+      ]
+      |> to_stream
 
-    result = CSV.decode!(stream) |> Enum.to_list
+    result = CSV.decode!(stream) |> Enum.to_list()
 
     assert result == [
-      [
-        "",
-        "",
-        "\r\nfield three of line one\r\ncontains \"quoted\" text, \r\nmultiple \"linebreaks\"\r\nand ends on a new line."
-      ],
-      [
-        "line two has",
-        "a simple, quoted second field\r\nwith one newline",
-        "and a standard third field"
-      ],
-      [
-        "line three begins with an escaped field,\r\n continues with",
-        "an escaped field,\r\nand ends",
-        "with\r\nan escaped field"
-      ],
-      [
-        "field two in\r\nline four",
-        "\r\nbegins and ends with a newline\r\n",
-        ", and field three\r\n\"\"\r\nis full of newlines and quotes\r\n"
-      ],
-      [
-        "line five has an empty line in field two",
-        "\r\n\r\n",
-        "\"and a doubly quoted third field\r\n\""
-      ],
-      [
-        "\"\"",
-        "\"\r\n\"\"\r\n",
-        "\""
-      ],
-      [
-        "line seven has an intermittent",
-        "quote\r\nright after\r\n\"a new line\r\nand\r\nends with a standard, \"",
-        "unquoted third field"
-      ]
-
-    ]
+             [
+               "",
+               "",
+               "\r\nfield three of line one\r\ncontains \"quoted\" text, \r\nmultiple \"linebreaks\"\r\nand ends on a new line."
+             ],
+             [
+               "line two has",
+               "a simple, quoted second field\r\nwith one newline",
+               "and a standard third field"
+             ],
+             [
+               "line three begins with an escaped field,\r\n continues with",
+               "an escaped field,\r\nand ends",
+               "with\r\nan escaped field"
+             ],
+             [
+               "field two in\r\nline four",
+               "\r\nbegins and ends with a newline\r\n",
+               ", and field three\r\n\"\"\r\nis full of newlines and quotes\r\n"
+             ],
+             [
+               "line five has an empty line in field two",
+               "\r\n\r\n",
+               "\"and a doubly quoted third field\r\n\""
+             ],
+             [
+               "\"\"",
+               "\"\r\n\"\"\r\n",
+               "\""
+             ],
+             [
+               "line seven has an intermittent",
+               "quote\r\nright after\r\n\"a new line\r\nand\r\nends with a standard, \"",
+               "unquoted third field"
+             ]
+           ]
   end
-
 end

--- a/test/exceptions_test.exs
+++ b/test/exceptions_test.exs
@@ -11,16 +11,17 @@ defmodule ExceptionsTest do
   end
 
   test "exception messaging about unfinished escape sequences" do
-    exception = EscapeSequenceError.
-                  exception(
-                    line: 1,
-                    escape_sequence: "SEQUENCE END",
-                    escape_max_lines: 2
-                  )
+    exception =
+      EscapeSequenceError.exception(
+        line: 1,
+        escape_sequence: "SEQUENCE END",
+        escape_max_lines: 2
+      )
+
     assert exception.message ==
-      "Escape sequence started on line 1 near \"SEQUENCE E\" did not terminate.\n\n" <>
-      "Escape sequences are allowed to span up to 2 lines. This threshold avoids " <>
-      "collecting the whole file into memory when an escape sequence does not terminate. " <>
-      "You can change it using the escape_max_lines option: https://hexdocs.pm/csv/CSV.html#decode/2"
+             "Escape sequence started on line 1 near \"SEQUENCE E\" did not terminate.\n\n" <>
+               "Escape sequences are allowed to span up to 2 lines. This threshold avoids " <>
+               "collecting the whole file into memory when an escape sequence does not terminate. " <>
+               "You can change it using the escape_max_lines option: https://hexdocs.pm/csv/CSV.html#decode/2"
   end
 end

--- a/test/support/stream_helpers.ex
+++ b/test/support/stream_helpers.ex
@@ -1,7 +1,5 @@
 defmodule TestSupport.StreamHelpers do
-
   def to_stream(list) when is_list(list) do
-    list |> Stream.map(&(&1))
+    list |> Stream.map(& &1)
   end
-
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start
+ExUnit.start()


### PR DESCRIPTION
This fixes the following issues when using csv:
```
==> csv
Compiling 10 files (.ex)
warning: outdented heredoc line. The contents inside the heredoc should be indented at the same level as the closing """. The following is forbidden:

    def text do
      """
    contents
      """
    end

Instead make sure the contents are indented as much as the heredoc closing:

    def text do
      """
      contents
      """
    end

The current heredoc line is indented too little
  lib/csv.ex:69

warning: String.strip/1 is deprecated, use String.trim/1
  lib/csv/decoding/parser.ex:78

Generated csv app
```

with:
```
mix --version
Erlang/OTP 21 [erts-10.0.2] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe] [dtrace]

Mix 1.6.6 (compiled with OTP 20)

mix hex
Hex v0.18.1
```

It also provides a formatter file to format the files according to elixir guidelines. To run, simply use `mix format` in your console.

