### PR TITLE
Fix indentation in list of options

### DIFF
--- a/lib/csv.ex
+++ b/lib/csv.ex
@@ -29,7 +29,7 @@ defmodule CSV do
         escape sequences
         :none -> Will not preprocess input and expects line by line input
         with multiple line escape sequences aggregated to one line
-  * `:validate_row_length` – If set to `false`, will disable validation for
+    * `:validate_row_length` – If set to `false`, will disable validation for
       row length. This will allow for rows with variable length. Defaults to
       `true`
     * `:escape_max_lines` – How many lines to maximally aggregate for multiline


### PR DESCRIPTION
Currently some of the options are indented as if they were part of the `validate_row_length` option:

<img width="918" alt="Screen Shot 2020-01-20 at 5 14 13 PM" src="https://user-images.githubusercontent.com/1412796/72761174-238a4f00-3ba9-11ea-9093-8c5474948393.png">
