### PR TITLE
Fix line number for row length error when headers is true

### DIFF
--- a/lib/csv/decoding/decoder.ex
+++ b/lib/csv/decoding/decoder.ex
@@ -180,9 +180,9 @@ defmodule CSV.Decoding.Decoder do
         {[{line, 0, false, false}], {false, options}}
     end
   end
-  defp add_row_length({line, _, headers}, {true, options}) when is_list(headers) do
+  defp add_row_length({line, index, headers}, {true, options}) when is_list(headers) do
     row_length = headers |> Enum.count()
-    {[{line, 0, headers, row_length}], {row_length, options}}
+    {[{line, index, headers, row_length}], {row_length, options}}
   end
   defp add_row_length({line, index, headers}, {row_length, options}) do
     {[{line, index, headers, row_length}], {row_length, options}}

--- a/test/decoding/headers_test.exs
+++ b/test/decoding/headers_test.exs
@@ -33,4 +33,42 @@ defmodule DecodingTests.HeadersTest do
              ok: %{:a => "c", :b => "d"}
            ]
   end
+
+  test "reports correct error when headers is false" do
+    stream = ["a,b", "c"] |> to_stream()
+    result = Decoder.decode(stream, headers: false) |> Enum.to_list()
+
+    assert result == [
+      {:ok, ["a", "b"]},
+      {:error, CSV.RowLengthError, "Row has length 1 - expected length 2", 1}
+    ]
+  end
+
+  test "reports correct error index when headers is true, error on index 1" do
+    stream = ["a,b", "c"] |> to_stream()
+    result = Decoder.decode(stream, headers: true) |> Enum.to_list()
+
+    assert result == [
+      {:error, CSV.RowLengthError, "Row has length 1 - expected length 2", 1}
+    ]
+  end
+
+  test "reports correct error index when headers is true, error on index 2" do
+    stream = ["a,b", "c,d", "e"] |> to_stream()
+    result = Decoder.decode(stream, headers: true) |> Enum.to_list()
+
+    assert result == [
+      {:ok, %{"a" => "c", "b" => "d"}},
+      {:error, CSV.RowLengthError, "Row has length 1 - expected length 2", 2}
+    ]
+  end
+
+  test "reports correct error index when headers is a list" do
+    stream = ["a"] |> to_stream()
+    result = Decoder.decode(stream, headers: [:a, :b]) |> Enum.to_list()
+
+    assert result == [
+      {:error, CSV.RowLengthError, "Row has length 1 - expected length 2", 0}
+    ]
+  end
 end


### PR DESCRIPTION
Fixes #93 

When the `headers` option is `true`, the index of line 2 (index 1) would be set to 0. In turn, that would give a wrong line number in any error occuring on this line.