### PR TITLE
Fixes #69, support duplicate headers

### DIFF
--- a/lib/csv/decoding/decoder.ex
+++ b/lib/csv/decoding/decoder.ex
@@ -129,7 +129,23 @@ defmodule CSV.Decoding.Decoder do
   end
 
   defp build_row(data, headers) when is_list(headers) do
-    {:ok, headers |> Enum.zip(data) |> Enum.into(%{})}
+    zipped_data =
+      headers
+      |> Enum.zip(data)
+      |> Enum.reduce(%{}, fn {k, v}, acc ->
+        case Map.get(acc, k, :default_value) do
+          arr when is_list(arr) ->
+            Map.put(acc, k, arr ++ [v])
+
+          :default_value ->
+            Map.put(acc, k, v)
+
+          x ->
+            Map.put(acc, k, [x, v])
+        end
+      end)
+
+    {:ok, zipped_data |> Enum.into(%{})}
   end
 
   defp build_row(data, _), do: {:ok, data}

--- a/test/decoding/headers_test.exs
+++ b/test/decoding/headers_test.exs
@@ -36,14 +36,14 @@ defmodule DecodingTests.HeadersTest do
 
   test "parses strings into maps when there are duplicate headers" do
     stream = [
-      "a,b,c,c,d",
-      "a1,b1,c1,c2,d1"
+      "a,b,c,c,d,d,d",
+      "a1,b1,c1,c2,d1,d2,d3"
     ] |> to_stream
 
     result = Decoder.decode(stream, headers: true) |> Enum.to_list()
 
     assert result |> Enum.sort() == [
-             ok: %{"a" => "a1", "b" => "b1", "c" => ["c1", "c2"], "d" => "d1"}
+             ok: %{"a" => "a1", "b" => "b1", "c" => ["c1", "c2"], "d" => ["d1","d2","d3"]}
            ]
   end
 

--- a/test/decoding/headers_test.exs
+++ b/test/decoding/headers_test.exs
@@ -34,6 +34,19 @@ defmodule DecodingTests.HeadersTest do
            ]
   end
 
+  test "parses strings into maps when there are duplicate headers" do
+    stream = [
+      "a,b,c,c,d",
+      "a1,b1,c1,c2,d1"
+    ] |> to_stream
+
+    result = Decoder.decode(stream, headers: true) |> Enum.to_list()
+
+    assert result |> Enum.sort() == [
+             ok: %{"a" => "a1", "b" => "b1", "c" => ["c1", "c2"], "d" => "d1"}
+           ]
+  end
+
   test "reports correct error when headers is false" do
     stream = ["a,b", "c"] |> to_stream()
     result = Decoder.decode(stream, headers: false) |> Enum.to_list()


### PR DESCRIPTION
Per [this issue](https://github.com/beatrichartz/csv/issues/69), parsing csv file with duplicate headers returns a map where values corresponding to those duplicate headers get clobbered.

In a slightly tweaked version of example from that issue, a csv with this content:
```
id,name,address,address,city,province
1,joe,123 city st,456 dup st,moosejaw,SK
```

Results in this map:
```
%{"id" => "1", "name" => "joe", "address" => "456 dup st", "city" => "moosejaw", "province" => "SK"}
```

Where "456 dup st" clobbers the original "123 city st" for the address column's value. This PR proposes returning the value as an array when a duplicate header is present:
```
%{"id" => "1", "name" => "joe", "address" => ["123 city st", "456 dup st"], "city" => "moosejaw", "province" => "SK"}
```