### PR TITLE
issue-85: Encode headers as Keyword list

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ the right place:
 # ["z,a\\r\\n", ",value!\\r\\n"]
 ````
 
+You can also specify a keyword list, the keys of the list will be used as the keys for the rows, 
+but the values will be the value used for the header row name in CSV output
+
+````elixir
+[%{a: "value!"}] |> CSV.encode(headers: [a: "x", b: "y"])
+# ["x,y\\r\\n", "value!,\\r\\n"]
+````
+
 You'll surely appreciate some [more info on `encode`](https://hexdocs.pm/csv/CSV.html#encode/2)
 
 ## Polymorphic encoding

--- a/lib/csv/encoding/encoder.ex
+++ b/lib/csv/encoding/encoder.ex
@@ -78,6 +78,7 @@ defmodule CSV.Encoding.Encoder do
   end
 
   defp get_headers(row, true), do: Map.keys(row)
+
   defp get_headers(_row, headers) do
     if Keyword.keyword?(headers) do
       Keyword.values(headers)
@@ -87,6 +88,7 @@ defmodule CSV.Encoding.Encoder do
   end
 
   defp get_values(row, true), do: Map.values(row)
+
   defp get_values(row, headers) do
     if Keyword.keyword?(headers) do
       headers |> Enum.map(fn {k, _} -> Map.get(row, k) end)

--- a/lib/csv/encoding/encoder.ex
+++ b/lib/csv/encoding/encoder.ex
@@ -78,10 +78,22 @@ defmodule CSV.Encoding.Encoder do
   end
 
   defp get_headers(row, true), do: Map.keys(row)
-  defp get_headers(_row, headers), do: headers
+  defp get_headers(_row, headers) do
+    if Keyword.keyword?(headers) do
+      Keyword.values(headers)
+    else
+      headers
+    end
+  end
 
   defp get_values(row, true), do: Map.values(row)
-  defp get_values(row, headers), do: headers |> Enum.map(&Map.get(row, &1))
+  defp get_values(row, headers) do
+    if Keyword.keyword?(headers) do
+      headers |> Enum.map(fn {k, _} -> Map.get(row, k) end)
+    else
+      headers |> Enum.map(&Map.get(row, &1))
+    end
+  end
 
   defp encode_row(row, options) do
     separator = options |> Keyword.get(:separator, @separator)

--- a/test/encoding/headers_test.exs
+++ b/test/encoding/headers_test.exs
@@ -11,4 +11,19 @@ defmodule EncodingTests.HeadersTest do
     result = Encoder.encode([%{"c" => 1, "b" => 2}], headers: ["c", "b", "a"]) |> Enum.to_list()
     assert result == ["c,b,a\r\n", "1,2,\r\n"]
   end
+
+  test "inserts value of keyword list from header param" do
+    result = Encoder.encode([%{a: 1, b: 2, c: 3}], headers: [a: "c", b: "b", c: "a"]) |> Enum.to_list()
+    assert result == ["c,b,a\r\n", "1,2,3\r\n"]
+  end
+
+  test "inserts value of keyword list from header param with extra columns" do
+    result = Encoder.encode([%{a: 1, b: 2, c: 3}], headers: [a: "c", b: "b", c: "a", d: "x"]) |> Enum.to_list()
+    assert result == ["c,b,a,x\r\n", "1,2,3,\r\n"]
+  end
+
+  test "inserts value of keyword list from header param with reordered columns" do
+    result = Encoder.encode([%{c: 3, b: 2, a: 1}], headers: [a: "c", b: "b", c: "a", d: "x"]) |> Enum.to_list()
+    assert result == ["c,b,a,x\r\n", "1,2,3,\r\n"]
+  end
 end

--- a/test/encoding/headers_test.exs
+++ b/test/encoding/headers_test.exs
@@ -13,17 +13,25 @@ defmodule EncodingTests.HeadersTest do
   end
 
   test "inserts value of keyword list from header param" do
-    result = Encoder.encode([%{a: 1, b: 2, c: 3}], headers: [a: "c", b: "b", c: "a"]) |> Enum.to_list()
+    result =
+      Encoder.encode([%{a: 1, b: 2, c: 3}], headers: [a: "c", b: "b", c: "a"]) |> Enum.to_list()
+
     assert result == ["c,b,a\r\n", "1,2,3\r\n"]
   end
 
   test "inserts value of keyword list from header param with extra columns" do
-    result = Encoder.encode([%{a: 1, b: 2, c: 3}], headers: [a: "c", b: "b", c: "a", d: "x"]) |> Enum.to_list()
+    result =
+      Encoder.encode([%{a: 1, b: 2, c: 3}], headers: [a: "c", b: "b", c: "a", d: "x"])
+      |> Enum.to_list()
+
     assert result == ["c,b,a,x\r\n", "1,2,3,\r\n"]
   end
 
   test "inserts value of keyword list from header param with reordered columns" do
-    result = Encoder.encode([%{c: 3, b: 2, a: 1}], headers: [a: "c", b: "b", c: "a", d: "x"]) |> Enum.to_list()
+    result =
+      Encoder.encode([%{c: 3, b: 2, a: 1}], headers: [a: "c", b: "b", c: "a", d: "x"])
+      |> Enum.to_list()
+
     assert result == ["c,b,a,x\r\n", "1,2,3,\r\n"]
   end
 end


### PR DESCRIPTION
**This PR addresses**
Encode headers as Keyword list #85

CSV.encode accepts a Keyword list as headers, the keys of that list will be used as the keys for the rows, but the value will be the value used for the header row name in CSV output.

````elixir
[%{a: "value!"}] |> CSV.encode(headers: [a: "x", b: "y"])
# ["x,y\\r\\n", "value!,\\r\\n"]
````

**Checklist**
- Tests added - Yes
- Coverage increases or stays the same - Yes
- Docs updated - updated Readme.md
- Changelog updated - No release from this PR
