### PR TITLE
Pass through non-UTF8 bytes in lines preprocessor

### DIFF
--- a/lib/csv/decoding/preprocessing/lines.ex
+++ b/lib/csv/decoding/preprocessing/lines.ex
@@ -152,6 +152,10 @@ defmodule CSV.Decoding.Preprocessing.Lines do
     starts_sequence?(tail, <<head::utf8>>, quoted, separator, sequence_start)
   end
 
+  defp starts_sequence?(<<head>> <> tail, _, quoted, separator, sequence_start) do
+    starts_sequence?(tail, <<head>>, quoted, separator, sequence_start)
+  end
+
   defp starts_sequence?("", _, quoted, _, sequence_start) do
     {quoted, sequence_start}
   end

--- a/test/csv_exceptions_test.exs
+++ b/test/csv_exceptions_test.exs
@@ -23,4 +23,13 @@ defmodule CSVExceptionsTest do
     end
   end
 
+  test "returns encoding errors with rows in normal mode" do
+    stream = [<<"Diego,Fern", 225, "ndez">>, "John,Smith"] |> to_stream
+    result = CSV.decode(stream) |> Enum.to_list()
+
+    assert result == [
+             error: "Invalid encoding on line 1",
+             ok: ~w(John Smith)
+           ]
+  end
 end


### PR DESCRIPTION
Attempting to `CSV.decode` a stream that contains non-UTF8 bytes raises a `FunctionClauseError`:

```
     ** (FunctionClauseError) no function clause matching in CSV.Decoding.Preprocessing.Lines.starts_sequence?/5

     The following arguments were given to CSV.Decoding.Preprocessing.Lines.starts_sequence?/5:

         # 1
         <<225, 110, 100, 101, 122>>

         # 2
         "n"

         # 3
         false

         # 4
         44

         # 5
         ""

     Attempted function clauses (showing 5 out of 5):

         defp starts_sequence?(<<34::utf8(), tail::binary()>>, last_token, false, separator, _) when last_token == <<separator::utf8()>>
         defp starts_sequence?(<<34::utf8(), tail::binary()>>, "", false, separator, _)
         defp starts_sequence?(<<34::utf8(), tail::binary()>>, _, quoted, separator, sequence_start)
         defp starts_sequence?(<<head::utf8(), tail::binary()>>, _, quoted, separator, sequence_start)
         defp starts_sequence?("", _, quoted, _, sequence_start)

     code: result = CSV.decode(stream) |> Enum.to_list()
     stacktrace:
       (csv 2.4.1) CSV.Decoding.Preprocessing.Lines.starts_sequence?/5
       (csv 2.4.1) lib/csv/decoding/preprocessing/lines.ex:85: CSV.Decoding.Preprocessing.Lines.start_sequence/3
       (elixir 1.13.0) lib/stream.ex:902: Stream.do_transform_user/6
```

This makes it impossible to handle encoding errors per-line or use machinery like `Decoder`'s `replacement` option.

The code that would prevent this crash was accidentally deleted in https://github.com/beatrichartz/csv/commit/4f5069b99b8c0e4387c9e31798aed508b3f9998f because it is "unused" for files that only contain valid UTF8.

This PR restores the deleted clause and adds a high-level test; existing tests cover `Decoder` and `Lexer` but not the complete pipeline.