### PR TITLE
Fix link wording

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule CSV.Mixfile do
     [
       maintainers: ["Beat Richartz"],
       licenses: ["MIT"],
-      links: %{GitGub: @source_url}
+      links: %{GitHub: @source_url}
     ]
   end
 


### PR DESCRIPTION
From https://hex.pm/packages/csv:

<img width="341" alt="CleanShot 2022-09-19 at 17 05 35@2x" src="https://user-images.githubusercontent.com/10141/191049855-b5faff52-64ac-49f0-abd7-6c148b14edd7.png">
