### PR TITLE
Fix GitGub typo in package definition

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule CSV.Mixfile do
     [
       maintainers: ["Beat Richartz"],
       licenses: ["MIT"],
-      links: %{GitGub: @source_url}
+      links: %{GitHub: @source_url}
     ]
   end
 


### PR DESCRIPTION
**This PR addresses**
- Fixes a `GitGub` typo in the package definition.

**Open questions**
- N/A

**Checklist**
- ~~Tests added~~
- ~~Coverage increases or stays the same~~
- ~~Docs updated~~
- ~~Changelog updated~~
