### PR TITLE
Use strip_fields instead of trim_fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### Upgrading from 2.x
 - **Parallelism has been removed**, alongside its options `:num_workers` and `:worker_work_ratio`. You can safely remove them.
 - **`StrayQuoteError` is now `StrayEscapeCharacterError`**. If you catch this error in your code, you need to rename it.
-- **The `:trim_fields` option needs to be replaced** with the `:field_transform` option:
+- **The `:strip_fields` option needs to be replaced** with the `:field_transform` option:
   ```elixir
   File.stream!("data.csv") |> CSV.decode(field_transform: &String.trim/1)
   ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The main goal for 3.x has been to streamline the library API and leverage binary
 
 - **Parallelism has been removed**, alongside its options `:num_workers` and `:worker_work_ratio`. You can safely remove them.
 - **`StrayQuoteError` is now `StrayEscapeCharacterError`**. If you catch this error in your code, you need to rename it.
-- **The `:trim_fields` option needs to be replaced** with the `:field_transform` option:
+- **The `:strip_fields` option needs to be replaced** with the `:field_transform` option:
   ```elixir
   File.stream!("data.csv") |> CSV.decode(field_transform: &String.trim/1)
   ```

--- a/lib/csv/defaults.ex
+++ b/lib/csv/defaults.ex
@@ -15,7 +15,7 @@ defmodule CSV.Defaults do
       @escape_max_lines 10
       @replacement nil
       @force_escaping false
-      @trim_fields false
+      @strip_fields false
       @escape_formulas false
       @unescape_formulas false
       @escape_formula_start ["=", "-", "+", "@"]


### PR DESCRIPTION
**This PR addresses**
- In previous versions `v2.x` were using `strip_fields` instead of `trim_fields`, it became confusing when looking at the trying to upgrade to `v3.x`

**Open questions**
- Anything that you wanted to discuss

**Checklist**
- Tests added
- Coverage increases or stays the same
- Docs updated
- Changelog updated
