### PR TITLE
Fix documentation missing closing backticks

### DIFF
--- a/lib/csv.ex
+++ b/lib/csv.ex
@@ -34,7 +34,7 @@ defmodule CSV do
   * `:validate_row_length` – When set to `true`, will take the first row of
       the csv or its headers and validate that following rows are of the same 
       length. Defaults to `false`.
-  * `:unescape_formulas    – When set to `true`, will remove formula escaping 
+  * `:unescape_formulas`   – When set to `true`, will remove formula escaping 
       inserted to prevent [CSV Injection](https://owasp.org/www-community/attacks/CSV_Injection).
 
   ## Examples
@@ -157,7 +157,7 @@ defmodule CSV do
   * `:validate_row_length` – When set to `true`, will take the first row of
       the csv or its headers and validate that following rows are of the same 
       length. Will raise an error if validation fails. Defaults to `false`.
-  * `:unescape_formulas    – When set to `true`, will remove formula escaping 
+  * `:unescape_formulas`   – When set to `true`, will remove formula escaping 
       inserted to prevent [CSV Injection](https://owasp.org/www-community/attacks/CSV_Injection).
 
   ## Examples
@@ -221,8 +221,8 @@ defmodule CSV do
       [[\"a\", \"b\"], [\"c\", \"d\"]]
 
   Replace invalid codepoints:
-      
-      iex> \"../test/fixtures/broken-encoding.csv\"
+
+      iex> "../test/fixtures/broken-encoding.csv"
       ...> |> Path.expand(__DIR__)
       ...> |> File.stream!()
       ...> |> CSV.decode!(field_transform: fn field ->
@@ -236,7 +236,7 @@ defmodule CSV do
       ...>   end
       ...> end)
       ...> |> Enum.take(2)
-      [[\"a\", \"b\", \"c\", \"?_?\"], [\"ಠ_ಠ\"]]
+      [["a", "b", "c", "?_?"], ["ಠ_ಠ"]]
 
   """
 

--- a/lib/csv/decoding/parser.ex
+++ b/lib/csv/decoding/parser.ex
@@ -23,7 +23,7 @@ defmodule CSV.Decoding.Parser do
       each field and can apply transformations. Defaults to identity function.
       This function will get called for every field and therefore should return 
       quickly.
-  * `:unescape_formulas    – When set to `true`, will remove formula escaping 
+  * `:unescape_formulas`   – When set to `true`, will remove formula escaping 
       inserted to prevent [CSV Injection](https://owasp.org/www-community/attacks/CSV_Injection).
 
   ## Examples


### PR DESCRIPTION
This was causing the 3.0.0 docs to not render the CSV.decode examples properly.

**This PR addresses**
- maybe: #114 (removes all warnings emitted during docs build process)

**Open questions**
- Not sure how you would like to handle versioning for docs-only changes, if it warrants a bump to 3.0.2 or not

**Checklist**
- n/a: Tests added
- n/a: Coverage increases or stays the same
- done: Docs updated
- not done: Changelog updated
