### PR TITLE
add decode option to redact line sequence data from CSV

### DIFF
--- a/lib/csv.ex
+++ b/lib/csv.ex
@@ -21,7 +21,7 @@ defmodule CSV do
       Must be a codepoint (syntax: ? + (your separator)).
   * `:escape_character`    – The escape character token to use, defaults to `?"`.
       Must be a codepoint (syntax: ? + (your escape character)).
-  * `:escape_max_lines`    – The number of lines an escape sequence is allowed 
+  * `:escape_max_lines`    – The number of lines an escape sequence is allowed
       to span, defaults to 10.
   * `:field_transform`     – A function with arity 1 that will get called with
       each field and can apply transformations. Defaults to identity function.

--- a/lib/csv.ex
+++ b/lib/csv.ex
@@ -38,6 +38,9 @@ defmodule CSV do
       length. Defaults to `false`.
   * `:unescape_formulas`   – When set to `true`, will remove formula escaping
       inserted to prevent [CSV Injection](https://owasp.org/www-community/attacks/CSV_Injection).
+  * `:redact_exception`   – When set to `true`, will remove line data from
+      exception message output. This is to prevent sensitive data leaking in
+      logs
 
   ## Examples
 
@@ -148,6 +151,7 @@ defmodule CSV do
           | {:validate_row_length, boolean()}
           | {:escape_character, char()}
           | {:escape_max_lines, integer()}
+          | {:redact_exception, boolean()}
 
   @spec decode(Enumerable.t(), [decode_options()]) :: Enumerable.t()
   def decode(stream, options \\ []) do

--- a/lib/csv/decoding/parser.ex
+++ b/lib/csv/decoding/parser.ex
@@ -51,6 +51,7 @@ defmodule CSV.Decoding.Parser do
           | {:separator, char}
           | {:escape_character, char}
           | {:field_transform, (String.t() -> String.t())}
+          | {:redact_exception, boolean()}
 
   @spec parse(Enumerable.t(), [parse_options()]) :: Enumerable.t()
   def parse(stream, options \\ []) do

--- a/lib/csv/exceptions.ex
+++ b/lib/csv/exceptions.ex
@@ -1,6 +1,6 @@
 defmodule CSV.RowLengthError do
   @moduledoc """
-  Raised at runtime when the CSV has rows of variable length 
+  Raised at runtime when the CSV has rows of variable length
   and `validate_row_length` is set to true.
   """
 
@@ -30,10 +30,11 @@ defmodule CSV.StrayEscapeCharacterError do
   def exception(options) do
     line = options |> Keyword.fetch!(:line)
     sequence = options |> Keyword.fetch!(:sequence)
+    redact = options |> Keyword.get(:redact, false)
 
     message =
       "Stray escape character on line #{line}:" <>
-        "\n\n#{sequence}" <>
+        "\n\n#{get_sequence(redact, sequence)}" <>
         "\n\nThis error often happens when the wrong separator or escape character has been applied.\n"
 
     %__MODULE__{
@@ -41,6 +42,9 @@ defmodule CSV.StrayEscapeCharacterError do
       message: message
     }
   end
+
+  defp get_sequence(true, _), do: "[redacted]"
+  defp get_sequence(false, sequence), do: sequence
 end
 
 defmodule CSV.EscapeSequenceError do

--- a/test/decoding/parser_exceptions_test.exs
+++ b/test/decoding/parser_exceptions_test.exs
@@ -41,9 +41,9 @@ defmodule DecodingTests.ParserExceptionsTest do
     errors = stream |> Parser.parse() |> Enum.to_list()
 
     assert errors == [
-             {:error, StrayEscapeCharacterError, [line: 1, sequence: "a\",\"be"]},
-             {:error, StrayEscapeCharacterError, [line: 3, sequence: "\"c,d\n\"e,f\"g\",h"]},
-             {:error, StrayEscapeCharacterError, [line: 3, sequence: "\"e,f\"g\",h"]},
+             {:error, StrayEscapeCharacterError, [line: 1, redact: false, sequence: "a\",\"be"]},
+             {:error, StrayEscapeCharacterError, [line: 3, sequence: "\"c,d\n\"e,f\"g\",h", redact: false]},
+             {:error, StrayEscapeCharacterError, [line: 3, sequence: "\"e,f\"g\",h", redact: false]},
              {:ok, ["j", "k"]}
            ]
   end
@@ -55,9 +55,9 @@ defmodule DecodingTests.ParserExceptionsTest do
       errors = stream |> Parser.parse() |> Enum.to_list()
 
       assert errors == [
-               {:error, StrayEscapeCharacterError, [line: 1, sequence: "a\",\"be"]},
-               {:error, StrayEscapeCharacterError, [line: 3, sequence: "\"c,d\n\"e,f\"g\",h"]},
-               {:error, StrayEscapeCharacterError, [line: 3, sequence: "\"e,f\"g\",h"]},
+               {:error, StrayEscapeCharacterError, [line: 1, redact: false, sequence: "a\",\"be"]},
+               {:error, StrayEscapeCharacterError, [line: 3, sequence: "\"c,d\n\"e,f\"g\",h", redact: false]},
+               {:error, StrayEscapeCharacterError, [line: 3, sequence: "\"e,f\"g\",h", redact: false]},
                {:ok, ["j", "k"]},
                {:ok, ["m", "l"]},
                {:ok, ["o", "p"]}
@@ -70,9 +70,9 @@ defmodule DecodingTests.ParserExceptionsTest do
     errors = stream |> Parser.parse() |> Enum.to_list()
 
     assert errors == [
-             {:error, StrayEscapeCharacterError, [line: 1, sequence: "\"b\"e"]},
-             {:error, StrayEscapeCharacterError, [line: 2, sequence: "\"c,\"d"]},
-             {:error, StrayEscapeCharacterError, [line: 3, sequence: "\"e,f\"g\",h"]},
+             {:error, StrayEscapeCharacterError, [line: 1, sequence: "\"b\"e", redact: false]},
+             {:error, StrayEscapeCharacterError, [line: 2, sequence: "\"c,\"d", redact: false]},
+             {:error, StrayEscapeCharacterError, [line: 3, sequence: "\"e,f\"g\",h", redact: false]},
              {:ok, ["j", "k"]}
            ]
   end
@@ -84,9 +84,9 @@ defmodule DecodingTests.ParserExceptionsTest do
       errors = stream |> Parser.parse() |> Enum.to_list()
 
       assert errors == [
-               {:error, StrayEscapeCharacterError, [line: 1, sequence: "\"b\"e"]},
-               {:error, StrayEscapeCharacterError, [line: 2, sequence: "\"c,\"d"]},
-               {:error, StrayEscapeCharacterError, [line: 3, sequence: "\"e,f\"g\",h"]},
+               {:error, StrayEscapeCharacterError, [line: 1, sequence: "\"b\"e", redact: false]},
+               {:error, StrayEscapeCharacterError, [line: 2, sequence: "\"c,\"d", redact: false]},
+               {:error, StrayEscapeCharacterError, [line: 3, sequence: "\"e,f\"g\",h", redact: false]},
                {:ok, ["j", "k"]}
              ]
     end)
@@ -97,9 +97,9 @@ defmodule DecodingTests.ParserExceptionsTest do
     errors = stream |> Parser.parse() |> Enum.to_list()
 
     assert errors == [
-             {:error, StrayEscapeCharacterError, [line: 1, sequence: "a\",\"be"]},
-             {:error, StrayEscapeCharacterError, [line: 3, sequence: "\"c,,d\n\"e,f\"g\",h"]},
-             {:error, StrayEscapeCharacterError, [line: 3, sequence: "\"e,f\"g\",h"]},
+             {:error, StrayEscapeCharacterError, [line: 1, redact: false, sequence: "a\",\"be"]},
+             {:error, StrayEscapeCharacterError, [line: 3, sequence: "\"c,,d\n\"e,f\"g\",h", redact: false]},
+             {:error, StrayEscapeCharacterError, [line: 3, sequence: "\"e,f\"g\",h", redact: false]},
              {:ok, ["j", "k"]}
            ]
   end
@@ -109,9 +109,9 @@ defmodule DecodingTests.ParserExceptionsTest do
     errors = stream |> Parser.parse() |> Enum.to_list()
 
     assert errors == [
-             {:error, StrayEscapeCharacterError, [line: 1, sequence: "a\",\"be"]},
+             {:error, StrayEscapeCharacterError, [line: 1, redact: false, sequence: "a\",\"be"]},
              {:error, StrayEscapeCharacterError,
-              [line: 2, sequence: "e,fg,hh\"", stream_halted: true]}
+              [line: 2, sequence: "e,fg,hh\"", redact: false, stream_halted: true]}
            ]
   end
 
@@ -122,9 +122,9 @@ defmodule DecodingTests.ParserExceptionsTest do
       errors = stream |> Parser.parse() |> Enum.to_list()
 
       assert errors == [
-               {:error, StrayEscapeCharacterError, [line: 1, sequence: "a\",\"be"]},
+               {:error, StrayEscapeCharacterError, [line: 1, redact: false, sequence: "a\",\"be"]},
                {:error, StrayEscapeCharacterError,
-                [line: 2, sequence: "e,fg,hh\"", stream_halted: true]}
+                [line: 2, sequence: "e,fg,hh\"", redact: false, stream_halted: true]}
              ]
     end)
   end
@@ -135,7 +135,7 @@ defmodule DecodingTests.ParserExceptionsTest do
 
     assert result == [
              {:error, StrayEscapeCharacterError,
-              [line: 3, sequence: "b,c\nd,e\n,f\"\" \"a", stream_halted: true]}
+              [line: 3, sequence: "b,c\nd,e\n,f\"\" \"a", stream_halted: true, redact: false]}
            ]
   end
 
@@ -274,7 +274,8 @@ defmodule DecodingTests.ParserExceptionsTest do
              {:error, StrayEscapeCharacterError,
               [
                 line: 2,
-                sequence: "\"be\nc,\"d\""
+                sequence: "\"be\nc,\"d\"",
+                redact: false
               ]},
              {:ok, ["c", "d"]},
              {:error, EscapeSequenceError,
@@ -308,21 +309,24 @@ defmodule DecodingTests.ParserExceptionsTest do
              {:error, StrayEscapeCharacterError,
               [
                 line: 3,
-                sequence: "\"\nElaine,29,\"unknwon \"\""
+                sequence: "\"\nElaine,29,\"unknwon \"\"",
+                redact: false
               ]},
              {:error, StrayEscapeCharacterError,
               [
                 line: 4,
-                sequence: "\"\nElaine,30,\"unknwon \"\""
+                sequence: "\"\nElaine,30,\"unknwon \"\"",
+                redact: false
               ]},
              {:error, StrayEscapeCharacterError,
               [
                 line: 6,
-                sequence: "\"\nKramer,40,kramerica\nGeorge,34,architect \"vandalay\" ind"
+                sequence: "\"\nKramer,40,kramerica\nGeorge,34,architect \"vandalay\" ind",
+                redact: false
               ]},
              {:ok, ["Kramer", "40", "kramerica"]},
              {:error, StrayEscapeCharacterError,
-              [line: 6, sequence: "architect \"vandalay\" ind"]},
+              [line: 6, redact: false, sequence: "architect \"vandalay\" ind"]},
              {:ok, ["Newman", "37", "postal, worker"]}
            ]
   end
@@ -341,21 +345,24 @@ defmodule DecodingTests.ParserExceptionsTest do
                {:error, StrayEscapeCharacterError,
                 [
                   line: 3,
-                  sequence: "\"\nElaine,29,\"unknwon \"\""
+                  sequence: "\"\nElaine,29,\"unknwon \"\"",
+                  redact: false
                 ]},
                {:error, StrayEscapeCharacterError,
                 [
                   line: 4,
-                  sequence: "\"\nElaine,30,\"unknwon \"\""
+                  sequence: "\"\nElaine,30,\"unknwon \"\"",
+                  redact: false
                 ]},
                {:error, StrayEscapeCharacterError,
                 [
                   line: 6,
-                  sequence: "\"\nKramer,40,kramerica\nGeorge,34,architect \"vandalay\" ind"
+                  sequence: "\"\nKramer,40,kramerica\nGeorge,34,architect \"vandalay\" ind",
+                  redact: false
                 ]},
                {:ok, ["Kramer", "40", "kramerica"]},
                {:error, StrayEscapeCharacterError,
-                [line: 6, sequence: "architect \"vandalay\" ind"]},
+                [line: 6, redact: false, sequence: "architect \"vandalay\" ind"]},
                {:ok, ["Newman", "37", "postal, worker"]}
              ]
     end)
@@ -371,7 +378,8 @@ defmodule DecodingTests.ParserExceptionsTest do
                {:error, StrayEscapeCharacterError,
                 [
                   line: 2,
-                  sequence: "\"be\nc,\"d\""
+                  sequence: "\"be\nc,\"d\"",
+                  redact: false
                 ]},
                {:ok, ["c", "d"]},
                {:error, EscapeSequenceError,

--- a/test/escaped_fields_exceptions_test.exs
+++ b/test/escaped_fields_exceptions_test.exs
@@ -54,4 +54,12 @@ defmodule DecodingTests.EscapedFieldsExceptionsTest do
       CSV.decode!(stream) |> Stream.run()
     end
   end
+
+  test "raises errors for stray quotes in strict mode and redacts sequence" do
+    stream = [",sensitive\",", ",c,d"] |> to_line_stream
+
+    assert_raise CSV.StrayEscapeCharacterError, ~r/\[redacted\]/, fn ->
+      CSV.decode!(stream, redact_exception: true) |> Stream.run()
+    end
+  end
 end

--- a/test/exceptions_test.exs
+++ b/test/exceptions_test.exs
@@ -56,4 +56,13 @@ defmodule ExceptionsTest do
     assert exception.message ==
              "Stray escape character on line 1:\n\nTHIS\n\nThis error often happens when the wrong separator or escape character has been applied.\n"
   end
+
+  test "exception messaging about stray escape character errors can be redacted" do
+    exception = StrayEscapeCharacterError.exception(line: 1, sequence: "sensitive", redact: true)
+
+    assert exception.message ==
+             "Stray escape character on line 1:\n\n[redacted]\n\nThis error often happens when the wrong separator or escape character has been applied.\n"
+
+    refute exception.message =~ "sensitive"
+  end
 end


### PR DESCRIPTION
**This PR addresses**
CSVs might contain sensitive data, so we could allow a decode option to not include that data as part of the exception messaging.

**Open questions**
It could be argued that this isn't needed at all and apps using this library could just not log this out when they get this exception. But for long standing apps, it might be easier for them to add this decode option in the few areas where they need to without changing any other telemetry or logging.

The naming from the option was inspired by the ecto field option `redact`. I thought this might be a similar situation.

Lastly, I notice we are just adding another parameter to all the functions here. This is outside the scope of this PR, but would it possibly be better to pass around the options starting at `create_row_transform`, and then extract them when needed down the line? 

**Checklist**
- Tests added ✅ 
- Coverage increases or stays the same 
- Docs updated ✅ 
- Changelog updated
