### PR TITLE
add decode option to redact line sequence data from CSV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
 
 permissions:
   contents: read
@@ -22,56 +22,56 @@ jobs:
             otp-version: 24.3.4
           - elixir-version: 1.12
             otp-version: 23.3.4
-          # - elixir-version: 1.11
-          #   otp-version: 23.3.4
-          # - elixir-version: '1.10'
-          #   otp-version: 22.3.4
-          # - elixir-version: 1.9
-          #   otp-version: 22.3.4
-          # - elixir-version: 1.8
-          #   otp-version: 21.3.8
+          - elixir-version: 1.11
+            otp-version: 23.3.4
+          - elixir-version: '1.10'
+            otp-version: 22.3.4
+          - elixir-version: 1.9
+            otp-version: 22.3.4
+          - elixir-version: 1.8
+            otp-version: 21.3.8
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Elixir
-        uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
-        with: ${{matrix.environment}}
-      - name: Restore dependencies cache
-        uses: actions/cache@v3
-        with:
-          path: deps/
-          key: deps-${{ runner.os }}-${{ matrix.environment.otp-version }}-${{ matrix.environment.elixir-version }}-${{ hashFiles('**/mix.lock') }}
-      - name: Restore build cache
-        uses: actions/cache@v3
-        with:
-          path: _build/test/
-          key: build-${{ runner.os }}-${{ matrix.environment.otp-version }}-${{ matrix.environment.elixir-version }}-${{ hashFiles('**/mix.lock') }}
-      - name: Install dependencies
-        run: |
-          mix local.rebar --force
-          mix local.hex --force
-          mix deps.get
-          mix compile
-      - name: Restore PLT cache
-        uses: actions/cache@v2
-        id: plt_cache
-        with:
-          key: |
-            ${{ runner.os }}-${{ matrix.environment.elixir-version }}-${{ matrix.environment.otp-version }}-plt
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.environment.elixir-version }}-${{ matrix.environment.otp-version }}-plt
-          path: |
-            priv/plts
+    - uses: actions/checkout@v3
+    - name: Set up Elixir
+      uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
+      with: ${{matrix.environment}}
+    - name: Restore dependencies cache
+      uses: actions/cache@v3
+      with:
+        path: deps/
+        key: deps-${{ runner.os }}-${{ matrix.environment.otp-version }}-${{ matrix.environment.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+    - name: Restore build cache
+      uses: actions/cache@v3
+      with:
+        path: _build/test/
+        key: build-${{ runner.os }}-${{ matrix.environment.otp-version }}-${{ matrix.environment.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+    - name: Install dependencies
+      run: |
+        mix local.rebar --force
+        mix local.hex --force
+        mix deps.get
+        mix compile
+    - name: Restore PLT cache
+      uses: actions/cache@v2
+      id: plt_cache
+      with:
+        key: |
+          ${{ runner.os }}-${{ matrix.environment.elixir-version }}-${{ matrix.environment.otp-version }}-plt
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.environment.elixir-version }}-${{ matrix.environment.otp-version }}-plt
+        path: |
+          priv/plts
 
-      - name: Create PLTs
-        if: steps.plt_cache.outputs.cache-hit != 'true'
-        run: mix dialyzer --plt
-        env:
-          MIX_ENV: test
+    - name: Create PLTs
+      if: steps.plt_cache.outputs.cache-hit != 'true'
+      run: mix dialyzer --plt
+      env:
+        MIX_ENV: test
 
-      - name: Run dialyzer
-        run: mix dialyzer --format github
-        env:
-          MIX_ENV: test
+    - name: Run dialyzer
+      run: mix dialyzer --format github
+      env:
+        MIX_ENV: test
   build:
     runs-on: ubuntu-20.04
     name: Build and Test on Elixir ${{matrix.environment.elixir-version}} / OTP ${{matrix.environment.otp-version}}
@@ -84,45 +84,45 @@ jobs:
             otp-version: 24.3.4
           - elixir-version: 1.12
             otp-version: 23.3.4
-          # - elixir-version: 1.11
-          #   otp-version: 23.3.4
-          # - elixir-version: "1.10"
-          #   otp-version: 22.3.4
-          # - elixir-version: 1.9
-          #   otp-version: 22.3.4
-          # - elixir-version: 1.8
-          #   otp-version: 21.3.8
-          # - elixir-version: 1.7
-          #   otp-version: 21.3.8
+          - elixir-version: 1.11
+            otp-version: 23.3.4
+          - elixir-version: '1.10'
+            otp-version: 22.3.4
+          - elixir-version: 1.9
+            otp-version: 22.3.4
+          - elixir-version: 1.8
+            otp-version: 21.3.8
+          - elixir-version: 1.7
+            otp-version: 21.3.8
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Elixir
-        uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
-        with: ${{matrix.environment}}
-      - name: Restore dependencies cache
-        uses: actions/cache@v3
-        with:
-          path: deps/
-          key: deps-${{ runner.os }}-${{ matrix.environment.otp-version }}-${{ matrix.environment.elixir-version }}-${{ hashFiles('**/mix.lock') }}
-      - name: Restore build cache
-        uses: actions/cache@v3
-        with:
-          path: _build/test/
-          key: build-${{ runner.os }}-${{ matrix.environment.otp-version }}-${{ matrix.environment.elixir-version }}-${{ hashFiles('**/mix.lock') }}
-      - name: Install dependencies
-        run: |
-          mix local.rebar --force
-          mix local.hex --force
-          mix deps.get
-          mix compile
-      - name: Run tests with coverage
-        if: matrix.environment.elixir-version == '1.14'
-        run: mix coveralls.github
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MIX_ENV: test
-      - name: Run tests
-        if: matrix.environment.elixir-version != '1.14'
-        run: mix test
-        env:
-          MIX_ENV: test
+    - uses: actions/checkout@v3
+    - name: Set up Elixir
+      uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
+      with: ${{matrix.environment}}
+    - name: Restore dependencies cache
+      uses: actions/cache@v3
+      with:
+        path: deps/
+        key: deps-${{ runner.os }}-${{ matrix.environment.otp-version }}-${{ matrix.environment.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+    - name: Restore build cache
+      uses: actions/cache@v3
+      with:
+        path: _build/test/
+        key: build-${{ runner.os }}-${{ matrix.environment.otp-version }}-${{ matrix.environment.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+    - name: Install dependencies
+      run: |
+        mix local.rebar --force
+        mix local.hex --force
+        mix deps.get
+        mix compile
+    - name: Run tests with coverage
+      if: matrix.environment.elixir-version == '1.14'
+      run: mix coveralls.github
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MIX_ENV: test
+    - name: Run tests
+      if: matrix.environment.elixir-version != '1.14'
+      run: mix test
+      env:
+        MIX_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   contents: read
@@ -22,56 +22,56 @@ jobs:
             otp-version: 24.3.4
           - elixir-version: 1.12
             otp-version: 23.3.4
-          - elixir-version: 1.11
-            otp-version: 23.3.4
-          - elixir-version: '1.10'
-            otp-version: 22.3.4
-          - elixir-version: 1.9
-            otp-version: 22.3.4
-          - elixir-version: 1.8
-            otp-version: 21.3.8
+          # - elixir-version: 1.11
+          #   otp-version: 23.3.4
+          # - elixir-version: '1.10'
+          #   otp-version: 22.3.4
+          # - elixir-version: 1.9
+          #   otp-version: 22.3.4
+          # - elixir-version: 1.8
+          #   otp-version: 21.3.8
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Elixir
-      uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
-      with: ${{matrix.environment}}
-    - name: Restore dependencies cache
-      uses: actions/cache@v3
-      with:
-        path: deps/
-        key: deps-${{ runner.os }}-${{ matrix.environment.otp-version }}-${{ matrix.environment.elixir-version }}-${{ hashFiles('**/mix.lock') }}
-    - name: Restore build cache
-      uses: actions/cache@v3
-      with:
-        path: _build/test/
-        key: build-${{ runner.os }}-${{ matrix.environment.otp-version }}-${{ matrix.environment.elixir-version }}-${{ hashFiles('**/mix.lock') }}
-    - name: Install dependencies
-      run: |
-        mix local.rebar --force
-        mix local.hex --force
-        mix deps.get
-        mix compile
-    - name: Restore PLT cache
-      uses: actions/cache@v2
-      id: plt_cache
-      with:
-        key: |
-          ${{ runner.os }}-${{ matrix.environment.elixir-version }}-${{ matrix.environment.otp-version }}-plt
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.environment.elixir-version }}-${{ matrix.environment.otp-version }}-plt
-        path: |
-          priv/plts
+      - uses: actions/checkout@v3
+      - name: Set up Elixir
+        uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
+        with: ${{matrix.environment}}
+      - name: Restore dependencies cache
+        uses: actions/cache@v3
+        with:
+          path: deps/
+          key: deps-${{ runner.os }}-${{ matrix.environment.otp-version }}-${{ matrix.environment.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+      - name: Restore build cache
+        uses: actions/cache@v3
+        with:
+          path: _build/test/
+          key: build-${{ runner.os }}-${{ matrix.environment.otp-version }}-${{ matrix.environment.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+      - name: Install dependencies
+        run: |
+          mix local.rebar --force
+          mix local.hex --force
+          mix deps.get
+          mix compile
+      - name: Restore PLT cache
+        uses: actions/cache@v2
+        id: plt_cache
+        with:
+          key: |
+            ${{ runner.os }}-${{ matrix.environment.elixir-version }}-${{ matrix.environment.otp-version }}-plt
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.environment.elixir-version }}-${{ matrix.environment.otp-version }}-plt
+          path: |
+            priv/plts
 
-    - name: Create PLTs
-      if: steps.plt_cache.outputs.cache-hit != 'true'
-      run: mix dialyzer --plt
-      env:
-        MIX_ENV: test
+      - name: Create PLTs
+        if: steps.plt_cache.outputs.cache-hit != 'true'
+        run: mix dialyzer --plt
+        env:
+          MIX_ENV: test
 
-    - name: Run dialyzer
-      run: mix dialyzer --format github
-      env:
-        MIX_ENV: test
+      - name: Run dialyzer
+        run: mix dialyzer --format github
+        env:
+          MIX_ENV: test
   build:
     runs-on: ubuntu-20.04
     name: Build and Test on Elixir ${{matrix.environment.elixir-version}} / OTP ${{matrix.environment.otp-version}}
@@ -84,45 +84,45 @@ jobs:
             otp-version: 24.3.4
           - elixir-version: 1.12
             otp-version: 23.3.4
-          - elixir-version: 1.11
-            otp-version: 23.3.4
-          - elixir-version: '1.10'
-            otp-version: 22.3.4
-          - elixir-version: 1.9
-            otp-version: 22.3.4
-          - elixir-version: 1.8
-            otp-version: 21.3.8
-          - elixir-version: 1.7
-            otp-version: 21.3.8
+          # - elixir-version: 1.11
+          #   otp-version: 23.3.4
+          # - elixir-version: "1.10"
+          #   otp-version: 22.3.4
+          # - elixir-version: 1.9
+          #   otp-version: 22.3.4
+          # - elixir-version: 1.8
+          #   otp-version: 21.3.8
+          # - elixir-version: 1.7
+          #   otp-version: 21.3.8
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Elixir
-      uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
-      with: ${{matrix.environment}}
-    - name: Restore dependencies cache
-      uses: actions/cache@v3
-      with:
-        path: deps/
-        key: deps-${{ runner.os }}-${{ matrix.environment.otp-version }}-${{ matrix.environment.elixir-version }}-${{ hashFiles('**/mix.lock') }}
-    - name: Restore build cache
-      uses: actions/cache@v3
-      with:
-        path: _build/test/
-        key: build-${{ runner.os }}-${{ matrix.environment.otp-version }}-${{ matrix.environment.elixir-version }}-${{ hashFiles('**/mix.lock') }}
-    - name: Install dependencies
-      run: |
-        mix local.rebar --force
-        mix local.hex --force
-        mix deps.get
-        mix compile
-    - name: Run tests with coverage
-      if: matrix.environment.elixir-version == '1.14'
-      run: mix coveralls.github
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        MIX_ENV: test
-    - name: Run tests
-      if: matrix.environment.elixir-version != '1.14'
-      run: mix test
-      env:
-        MIX_ENV: test
+      - uses: actions/checkout@v3
+      - name: Set up Elixir
+        uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
+        with: ${{matrix.environment}}
+      - name: Restore dependencies cache
+        uses: actions/cache@v3
+        with:
+          path: deps/
+          key: deps-${{ runner.os }}-${{ matrix.environment.otp-version }}-${{ matrix.environment.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+      - name: Restore build cache
+        uses: actions/cache@v3
+        with:
+          path: _build/test/
+          key: build-${{ runner.os }}-${{ matrix.environment.otp-version }}-${{ matrix.environment.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+      - name: Install dependencies
+        run: |
+          mix local.rebar --force
+          mix local.hex --force
+          mix deps.get
+          mix compile
+      - name: Run tests with coverage
+        if: matrix.environment.elixir-version == '1.14'
+        run: mix coveralls.github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MIX_ENV: test
+      - name: Run tests
+        if: matrix.environment.elixir-version != '1.14'
+        run: mix test
+        env:
+          MIX_ENV: test

--- a/lib/csv/exceptions.ex
+++ b/lib/csv/exceptions.ex
@@ -1,6 +1,6 @@
 defmodule CSV.RowLengthError do
   @moduledoc """
-  Raised at runtime when the CSV has rows of variable length 
+  Raised at runtime when the CSV has rows of variable length
   and `validate_row_length` is set to true.
   """
 
@@ -30,10 +30,11 @@ defmodule CSV.StrayEscapeCharacterError do
   def exception(options) do
     line = options |> Keyword.fetch!(:line)
     sequence = options |> Keyword.fetch!(:sequence)
+    redact = options |> Keyword.get(:redact, false)
 
     message =
       "Stray escape character on line #{line}:" <>
-        "\n\n#{sequence}" <>
+        "\n\n#{get_sequence(redact, sequence)}" <>
         "\n\nThis error often happens when the wrong separator or escape character has been applied.\n"
 
     %__MODULE__{
@@ -41,6 +42,9 @@ defmodule CSV.StrayEscapeCharacterError do
       message: message
     }
   end
+
+  defp get_sequence(true, _), do: "[redacted]"
+  defp get_sequence(false, sequence), do: sequence
 end
 
 defmodule CSV.EscapeSequenceError do

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule CSV.Mixfile do
 
   defp deps do
     [
-      {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
+      {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.15", only: :test},
       {:benchfella, ">= 0.0.0", only: :bench},

--- a/test/escaped_fields_exceptions_test.exs
+++ b/test/escaped_fields_exceptions_test.exs
@@ -54,4 +54,12 @@ defmodule DecodingTests.EscapedFieldsExceptionsTest do
       CSV.decode!(stream) |> Stream.run()
     end
   end
+
+  test "raises errors for stray quotes in strict mode and redacts sequence" do
+    stream = [",sensitive\",", ",c,d"] |> to_line_stream
+
+    assert_raise CSV.StrayEscapeCharacterError, ~r/\[redacted\]/, fn ->
+      CSV.decode!(stream, redact_exception: true) |> Stream.run()
+    end
+  end
 end

--- a/test/exceptions_test.exs
+++ b/test/exceptions_test.exs
@@ -56,4 +56,13 @@ defmodule ExceptionsTest do
     assert exception.message ==
              "Stray escape character on line 1:\n\nTHIS\n\nThis error often happens when the wrong separator or escape character has been applied.\n"
   end
+
+  test "exception messaging about stray escape character errors can be redacted" do
+    exception = StrayEscapeCharacterError.exception(line: 1, sequence: "sensitive", redact: true)
+
+    assert exception.message ==
+             "Stray escape character on line 1:\n\n[redacted]\n\nThis error often happens when the wrong separator or escape character has been applied.\n"
+
+    refute exception.message =~ "sensitive"
+  end
 end


### PR DESCRIPTION
**This PR addresses**
CSVs might contain sensitive data, so we could allow a decode option to not include that data as part of the exception messaging.

**Open questions**
It could be argued that this isn't needed at all and apps using this library could just not log this out when they get this exception. But for long standing apps, it might be easier for them to add this decode option in the few areas where they need to without changing any other telemetry or logging.

The naming from the option was inspired by the ecto field option `redact`. I thought this might be a similar situation.

**Checklist**
- Tests added ✅ 
- Coverage increases or stays the same 
- Docs updated ✅ 
- Changelog updated
