### PR TITLE
Only remove the unescape prefix character when parsing

### DIFF
--- a/lib/csv/decoding/decoder.ex
+++ b/lib/csv/decoding/decoder.ex
@@ -22,7 +22,7 @@ defmodule CSV.Decoding.Decoder do
       Must be a codepoint (syntax: ? + (your separator)).
   * `:escape_character`    – The escape character token to use, defaults to `?"`.
       Must be a codepoint (syntax: ? + (your escape character)).
-  * `:escape_max_lines`    – The number of lines an escape sequence is allowed 
+  * `:escape_max_lines`    – The number of lines an escape sequence is allowed
       to span, defaults to 10.
   * `:field_transform`     – A function with arity 1 that will get called with
       each field and can apply transformations. Defaults to identity function.
@@ -37,7 +37,7 @@ defmodule CSV.Decoding.Decoder do
   * `:validate_row_length` – When set to `true`, will take the first row of
       the csv or its headers and validate that following rows are of the same
       length. Defaults to `false`.
-  * `:escape_formulas`      – When set to `true`, will remove formula escaping
+  * `:unescape_formulas`   – When set to `true`, will remove formula escaping
       inserted to prevent [CSV Injection](https://owasp.org/www-community/attacks/CSV_Injection).
 
   ## Examples

--- a/lib/csv/decoding/parser.ex
+++ b/lib/csv/decoding/parser.ex
@@ -19,11 +19,11 @@ defmodule CSV.Decoding.Parser do
 
   * `:separator`           – The separator token to use, defaults to `?,`.
       Must be a codepoint (syntax: ? + (your separator)).
-  * `:field_transform`     – A function with arity 1 that will get called with 
+  * `:field_transform`     – A function with arity 1 that will get called with
       each field and can apply transformations. Defaults to identity function.
-      This function will get called for every field and therefore should return 
+      This function will get called for every field and therefore should return
       quickly.
-  * `:unescape_formulas`   – When set to `true`, will remove formula escaping 
+  * `:unescape_formulas`   – When set to `true`, will remove formula escaping
       inserted to prevent [CSV Injection](https://owasp.org/www-community/attacks/CSV_Injection).
 
   ## Examples
@@ -88,11 +88,14 @@ defmodule CSV.Decoding.Parser do
     unescape_formulas = options |> Keyword.get(:unescape_formulas, @unescape_formulas)
 
     if unescape_formulas do
-      formula_pattern = :binary.compile_pattern(@escape_formula_start)
+      formula_pattern =
+        @escape_formula_start
+        |> Enum.map(fn char -> @escape_formula_prefix <> char end)
+        |> :binary.compile_pattern()
 
       fn field ->
         case :binary.match(field, formula_pattern) do
-          {1, _} -> binary_part(field, 1, byte_size(field) - 1)
+          {0, _} -> binary_part(field, 1, byte_size(field) - 1)
           _ -> field
         end
       end

--- a/lib/csv/defaults.ex
+++ b/lib/csv/defaults.ex
@@ -18,6 +18,7 @@ defmodule CSV.Defaults do
       @escape_formulas false
       @unescape_formulas false
       @escape_formula_start ["=", "-", "+", "@"]
+      @escape_formula_prefix "'"
     end
   end
 end

--- a/lib/csv/encoding/encode.ex
+++ b/lib/csv/encoding/encode.ex
@@ -47,7 +47,7 @@ defimpl CSV.Encode, for: BitString do
 
     data =
       if escape_formulas and String.starts_with?(data, @escape_formula_start) do
-        "'" <> data
+        @escape_formula_prefix <> data
       else
         data
       end

--- a/test/decoding/parser_test.exs
+++ b/test/decoding/parser_test.exs
@@ -151,14 +151,25 @@ defmodule DecodingTests.ParserTest do
   end
 
   test "removes escaping for formula when unescape_formulas is set to true" do
-    input = [["=1+1", ~S(=1+2";=1+2), ~S(=1+2'" ;,=1+2)], ["-10+7"], ["+10+7"], ["@A1:A10"]]
+    input = [
+      ["=1+1", ~S(=1+2";=1+2), ~S(=1+2'" ;,=1+2)],
+      ["-10+7"],
+      ["+10+7"],
+      ["@A1:A10"],
+      ["X-1"],
+      ["B+1"],
+      ["C=1"]
+    ]
 
     assert encode_decode_loop([input], escape_formulas: true, unescape_formulas: true) == [
              ok: [
                "=1+1=1+2\";=1+2=1+2'\" ;,=1+2",
                "-10+7",
                "+10+7",
-               "@A1:A10"
+               "@A1:A10",
+               "X-1",
+               "B+1",
+               "C=1"
              ]
            ]
   end


### PR DESCRIPTION


**This PR addresses**
* Currently the `unescape_formulas` option when parsing will remove any first character of a cell as long as the second character is part of the `@escape_formula_start`. This causes issues when the data is something like this:

  ``` "A-1","B+2","C=3","'@D" ```

  which should parse to this:

  ``` ["A-1", "B+2", "C=3", "@D"] ```

  but parses to this instead:

  ``` ["-1", "+2", "=3", "@D"] ```

  This change will check that the first character is actually the escape character we want before removing it.

* Slight fix up of the documentation