### PR TITLE
fixes #132

### DIFF
--- a/lib/csv/decoding/decoder.ex
+++ b/lib/csv/decoding/decoder.ex
@@ -22,7 +22,7 @@ defmodule CSV.Decoding.Decoder do
       Must be a codepoint (syntax: ? + (your separator)).
   * `:escape_character`    – The escape character token to use, defaults to `?"`.
       Must be a codepoint (syntax: ? + (your escape character)).
-  * `:escape_max_lines`    – The number of lines an escape sequence is allowed 
+  * `:escape_max_lines`    – The number of lines an escape sequence is allowed
       to span, defaults to 10.
   * `:field_transform`     – A function with arity 1 that will get called with
       each field and can apply transformations. Defaults to identity function.

--- a/test/decoding/parser_exceptions_test.exs
+++ b/test/decoding/parser_exceptions_test.exs
@@ -65,6 +65,16 @@ defmodule DecodingTests.ParserExceptionsTest do
     end)
   end
 
+  test "includes an error for rows with unescaped quotes and no newline" do
+    errors = Parser.parse(["a,b\n", "c,\"d,e"]) |> Enum.to_list()
+
+    assert errors == [
+             {:ok, ["a", "b"]},
+             {:error, CSV.StrayEscapeCharacterError,
+             [line: 2, sequence: "d,e", stream_halted: true]}
+           ]
+  end
+
   test "includes an error for rows with unescaped quotes in escape sequences on the same line" do
     stream = ["a,\"b\"e", "\"c,\"d", "\"e,f\"g\",h", "j,k"] |> to_line_stream
     errors = stream |> Parser.parse() |> Enum.to_list()


### PR DESCRIPTION
I added another arg to `parse_to_end` that compares the prior sequence passed to the current sequence, and if they are the same then the stream halts with `StrayEscapeCharacterError`.

I'm not sure if that covers all edge cases, but all tests pass including the error from #132.

I added another test to check for this scenario.